### PR TITLE
Fix tests that were missing `#[test]` attributes.

### DIFF
--- a/src/ray.rs
+++ b/src/ray.rs
@@ -96,6 +96,7 @@ mod ray_tests {
         assert_eq!(ray.position(2.5), tuple::point(4.5, 3.0, 4.0));
     }
 
+    #[test]
     fn test_ray_intersects_a_sphere_at_two_points() {
         /*
            Sphere at origin, ray along the z
@@ -115,8 +116,8 @@ mod ray_tests {
         let intersections = ray.intersect(&sphere);
 
         assert_eq!(intersections.len(), 2);
-        assert_eq!(intersections[1].t, 4.0_f64);
-        assert_eq!(intersections[2].t, 6.0_f64);
+        assert_eq!(intersections[0].t, 4.0_f64);
+        assert_eq!(intersections[1].t, 6.0_f64);
     }
 
     #[test]

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -241,6 +241,7 @@ mod tuple_tests {
         assert_eq!(point1 - vector, expected_point);
     }
 
+    #[test]
     fn test_subtracting_two_vectors() {
         let vector1 = tuple::vector(3.0, 2.0, 1.0);
         let vector2 = tuple::vector(5.0, 6.0, 7.0);


### PR DESCRIPTION
Without the `#[test]` attribute tests aren't collected when running the
tests. The first was found by stumbling across it. After that I used
this command to find the rest:

    rg --multiline "[^#\[test\]]\n\s+fn test_"

Adding one of the attributes made me realize that one of the tests was
broken.