### PR TITLE
Add a builder interface to the World.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,6 @@ a change that you expect to improve performance and know if it worked on not.
 
 ## Possible improvements
 
-- Add multiple light sources.
-- Builder interface for worlds.
+- Add multiple light sources (note for this on 138 of the book).
 - Builder interface for shapes.
+- Update setting of transformation matrices

--- a/benches/simple_world.rs
+++ b/benches/simple_world.rs
@@ -19,21 +19,21 @@ mod test_helpers {
     }
 
     pub fn create_simple_world_with_planes() -> world::World {
-        let mut world = world::world();
+        let mut builder = world::WorldBuilder::new();
 
         // Create a floor and add it to the scene
-        {
+        builder.add_shape({
             let mut floor = shape::Shape::default_plane();
             floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
             let mut material = material::material();
             material.color = color::color(1.0, 0.9, 0.9);
             material.specular = 0.0;
             floor.material = material;
-            world.shapes.push(floor);
-        }
+            floor
+        });
 
         // Add a sphere to the center
-        {
+        builder.add_shape({
             let mut middle = shape::Shape::default_sphere();
             middle.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-0.5, 1.0, 0.5));
             let mut material = material::material();
@@ -41,11 +41,11 @@ mod test_helpers {
             material.diffuse = 0.7;
             material.specular = 0.3;
             middle.material = material;
-            world.shapes.push(middle);
-        }
+            middle
+        });
 
         // Add a small green sphere on the right
-        {
+        builder.add_shape({
             let mut right = shape::Shape::default_sphere();
             right.set_transformation_matrix(
                 matrix::Matrix4::IDENTITY
@@ -57,11 +57,11 @@ mod test_helpers {
             material.diffuse = 0.7;
             material.specular = 0.3;
             right.material = material;
-            world.shapes.push(right);
-        }
+            right
+        });
 
         // Add a smaller green sphere on the left
-        {
+        builder.add_shape({
             let mut left = shape::Shape::default_sphere();
             left.set_transformation_matrix(
                 matrix::Matrix4::IDENTITY
@@ -73,15 +73,16 @@ mod test_helpers {
             material.diffuse = 0.7;
             material.specular = 0.3;
             left.material = material;
-            world.shapes.push(left);
-        }
+            left
+        });
 
         // Let there be light
-        let white_point_light =
-            lights::point_light(tuple::Point::new(-10.0, 10.0, -10.0), color::white());
-        world.light = Some(white_point_light);
+        builder.add_light_source(lights::point_light(
+            tuple::Point::new(-10.0, 10.0, -10.0),
+            color::white(),
+        ));
 
-        return world;
+        return builder.world;
     }
 }
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -183,9 +183,9 @@ mod camera_tests {
         use crate::material;
         use crate::shape;
 
-        let mut world = world::world();
+        let mut builder = world::WorldBuilder::new();
         // Add  big sphere to the center so that the whole image is full of something
-        {
+        builder.add_shape({
             let mut big_guy = shape::Shape::default_sphere();
             big_guy.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(5.0, 5.0, 5.0));
             let mut material = material::material();
@@ -193,12 +193,13 @@ mod camera_tests {
             material.diffuse = 0.7;
             material.specular = 0.3;
             big_guy.material = material;
-            world.shapes.push(big_guy);
-        }
+            big_guy
+        });
         // Let there be light
-        let white_point_light =
-            lights::point_light(tuple::Point::new(-10.0, 10.0, -10.0), color::white());
-        world.light = Some(white_point_light);
+        builder.add_light_source(lights::point_light(
+            tuple::Point::new(-10.0, 10.0, -10.0),
+            color::white(),
+        ));
 
         let mut camera = camera::Camera::new(11, 11, std::f64::consts::PI / 2.0);
         let from = tuple::Point::new(0.0, 0.0, -5.0);
@@ -206,7 +207,7 @@ mod camera_tests {
         let up = tuple::Vector::new(0.0, 1.0, 0.0);
         camera.transform = transformation::view_transform(&from, &to, &up);
 
-        let image = camera.render(&world);
+        let image = camera.render(&builder.world);
 
         // Check the corners
         assert_color_approx_eq!(

--- a/tests/render_pattern_test.rs
+++ b/tests/render_pattern_test.rs
@@ -11,21 +11,21 @@ const SCALE: u32 = 1;
 
 #[test]
 fn test_checkered_sphere() -> Result<(), std::io::Error> {
-    let mut world = world::world();
+    let mut builder = world::WorldBuilder::new();
 
     // Create a floor and add it to the scene
-    {
+    builder.add_shape({
         let mut floor = shape::Shape::default_sphere();
         floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
         let mut material = material::material();
         material.color = color::color(1.0, 0.9, 0.9);
         material.specular = 0.0;
         floor.material = material;
-        world.shapes.push(floor);
-    }
+        floor
+    });
 
     // Add a sphere to the left
-    {
+    builder.add_shape({
         let mut left = shape::Shape::default_sphere();
         left.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-1.5, 1.0, 0.5));
         let pattern = patterns::Pattern::checkers(color::black(), color::white());
@@ -35,11 +35,11 @@ fn test_checkered_sphere() -> Result<(), std::io::Error> {
         material.specular = 0.3;
         material.pattern = Some(pattern);
         left.material = material;
-        world.shapes.push(left);
-    }
+        left
+    });
 
     // Add a sphere to the right
-    {
+    builder.add_shape({
         let mut right = shape::Shape::default_sphere();
         right.set_transformation_matrix(
             matrix::Matrix4::IDENTITY
@@ -53,13 +53,14 @@ fn test_checkered_sphere() -> Result<(), std::io::Error> {
         material.specular = 0.3;
         material.pattern = Some(pattern);
         right.material = material;
-        world.shapes.push(right);
-    }
+        right
+    });
 
     // Let there be light
-    let white_point_light =
-        lights::point_light(tuple::Point::new(-10.0, 10.0, -10.0), color::white());
-    world.light = Some(white_point_light);
+    builder.add_light_source(lights::point_light(
+        tuple::Point::new(-10.0, 10.0, -10.0),
+        color::white(),
+    ));
 
     let mut camera = camera::Camera::new(100 * SCALE, 50 * SCALE, std::f64::consts::PI / 3.0);
     camera.transform = transformation::view_transform(
@@ -68,7 +69,7 @@ fn test_checkered_sphere() -> Result<(), std::io::Error> {
         &tuple::Vector::new(0.0, 1.0, 0.0),
     );
 
-    let canvas = camera.render(&world);
+    let canvas = camera.render(&builder.world);
 
     let expected_image =
         shared_test_helpers::read_image_from_fixture_file("checkered_sphere").unwrap();
@@ -85,21 +86,21 @@ fn test_checkered_sphere() -> Result<(), std::io::Error> {
 
 #[test]
 fn test_gradient_sphere() -> Result<(), std::io::Error> {
-    let mut world = world::world();
+    let mut builder = world::WorldBuilder::new();
 
     // Create a floor and add it to the scene
-    {
+    builder.add_shape({
         let mut floor = shape::Shape::default_sphere();
         floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
         let mut material = material::material();
         material.color = color::color(1.0, 0.9, 0.9);
         material.specular = 0.0;
         floor.material = material;
-        world.shapes.push(floor);
-    }
+        floor
+    });
 
     // Add a sphere to the left
-    {
+    builder.add_shape({
         let mut left = shape::Shape::default_sphere();
         left.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-1.5, 1.0, 0.5));
         let pattern = patterns::Pattern::gradient(color::black(), color::white());
@@ -109,11 +110,11 @@ fn test_gradient_sphere() -> Result<(), std::io::Error> {
         material.specular = 0.3;
         material.pattern = Some(pattern);
         left.material = material;
-        world.shapes.push(left);
-    }
+        left
+    });
 
     // Add a sphere to the right
-    {
+    builder.add_shape({
         let mut right = shape::Shape::default_sphere();
         right.set_transformation_matrix(
             matrix::Matrix4::IDENTITY
@@ -127,13 +128,14 @@ fn test_gradient_sphere() -> Result<(), std::io::Error> {
         material.specular = 0.3;
         material.pattern = Some(pattern);
         right.material = material;
-        world.shapes.push(right);
-    }
+        right
+    });
 
     // Let there be light
-    let white_point_light =
-        lights::point_light(tuple::Point::new(-10.0, 10.0, -10.0), color::white());
-    world.light = Some(white_point_light);
+    builder.add_light_source(lights::point_light(
+        tuple::Point::new(-10.0, 10.0, -10.0),
+        color::white(),
+    ));
 
     let mut camera = camera::Camera::new(100 * SCALE, 50 * SCALE, std::f64::consts::PI / 3.0);
     camera.transform = transformation::view_transform(
@@ -142,7 +144,7 @@ fn test_gradient_sphere() -> Result<(), std::io::Error> {
         &tuple::Vector::new(0.0, 1.0, 0.0),
     );
 
-    let canvas = camera.render(&world);
+    let canvas = camera.render(&builder.world);
 
     let expected_image =
         shared_test_helpers::read_image_from_fixture_file("gradient_sphere").unwrap();
@@ -159,21 +161,21 @@ fn test_gradient_sphere() -> Result<(), std::io::Error> {
 
 #[test]
 fn test_ring_sphere() -> Result<(), std::io::Error> {
-    let mut world = world::world();
+    let mut builder = world::WorldBuilder::new();
 
     // Create a floor and add it to the scene
-    {
+    builder.add_shape({
         let mut floor = shape::Shape::default_sphere();
         floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
         let mut material = material::material();
         material.color = color::color(1.0, 0.9, 0.9);
         material.specular = 0.0;
         floor.material = material;
-        world.shapes.push(floor);
-    }
+        floor
+    });
 
     // Add a sphere to the left
-    {
+    builder.add_shape({
         let mut left = shape::Shape::default_sphere();
         left.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-1.5, 1.0, 0.5));
         let mut pattern = patterns::Pattern::ring(color::black(), color::white());
@@ -188,11 +190,11 @@ fn test_ring_sphere() -> Result<(), std::io::Error> {
         material.specular = 0.3;
         material.pattern = Some(pattern);
         left.material = material;
-        world.shapes.push(left);
-    }
+        left
+    });
 
     // Add a sphere to the right
-    {
+    builder.add_shape({
         let mut right = shape::Shape::default_sphere();
         right.set_transformation_matrix(
             matrix::Matrix4::IDENTITY
@@ -209,13 +211,14 @@ fn test_ring_sphere() -> Result<(), std::io::Error> {
         material.specular = 0.3;
         material.pattern = Some(pattern);
         right.material = material;
-        world.shapes.push(right);
-    }
+        right
+    });
 
     // Let there be light
-    let white_point_light =
-        lights::point_light(tuple::Point::new(-10.0, 10.0, -10.0), color::white());
-    world.light = Some(white_point_light);
+    builder.add_light_source(lights::point_light(
+        tuple::Point::new(-10.0, 10.0, -10.0),
+        color::white(),
+    ));
 
     let mut camera = camera::Camera::new(100 * SCALE, 50 * SCALE, std::f64::consts::PI / 3.0);
     camera.transform = transformation::view_transform(
@@ -224,7 +227,7 @@ fn test_ring_sphere() -> Result<(), std::io::Error> {
         &tuple::Vector::new(0.0, 1.0, 0.0),
     );
 
-    let canvas = camera.render(&world);
+    let canvas = camera.render(&builder.world);
 
     let expected_image = shared_test_helpers::read_image_from_fixture_file("ring_sphere").unwrap();
 
@@ -240,21 +243,21 @@ fn test_ring_sphere() -> Result<(), std::io::Error> {
 
 #[test]
 fn test_stripe_sphere() -> Result<(), std::io::Error> {
-    let mut world = world::world();
+    let mut builder = world::WorldBuilder::new();
 
     // Create a floor and add it to the scene
-    {
+    builder.add_shape({
         let mut floor = shape::Shape::default_sphere();
         floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
         let mut material = material::material();
         material.color = color::color(1.0, 0.9, 0.9);
         material.specular = 0.0;
         floor.material = material;
-        world.shapes.push(floor);
-    }
+        floor
+    });
 
     // Add a sphere to the left
-    {
+    builder.add_shape({
         let mut left = shape::Shape::default_sphere();
         left.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-1.5, 1.0, 0.5));
         let mut pattern = patterns::Pattern::stripe(color::black(), color::white());
@@ -269,11 +272,11 @@ fn test_stripe_sphere() -> Result<(), std::io::Error> {
         material.specular = 0.3;
         material.pattern = Some(pattern);
         left.material = material;
-        world.shapes.push(left);
-    }
+        left
+    });
 
     // Add a sphere to the right
-    {
+    builder.add_shape({
         let mut right = shape::Shape::default_sphere();
         right.set_transformation_matrix(
             matrix::Matrix4::IDENTITY
@@ -287,13 +290,14 @@ fn test_stripe_sphere() -> Result<(), std::io::Error> {
         material.specular = 0.3;
         material.pattern = Some(pattern);
         right.material = material;
-        world.shapes.push(right);
-    }
+        right
+    });
 
     // Let there be light
-    let white_point_light =
-        lights::point_light(tuple::Point::new(-10.0, 10.0, -10.0), color::white());
-    world.light = Some(white_point_light);
+    builder.add_light_source(lights::point_light(
+        tuple::Point::new(-10.0, 10.0, -10.0),
+        color::white(),
+    ));
 
     let mut camera = camera::Camera::new(100 * SCALE, 50 * SCALE, std::f64::consts::PI / 3.0);
     camera.transform = transformation::view_transform(
@@ -302,7 +306,7 @@ fn test_stripe_sphere() -> Result<(), std::io::Error> {
         &tuple::Vector::new(0.0, 1.0, 0.0),
     );
 
-    let canvas = camera.render(&world);
+    let canvas = camera.render(&builder.world);
 
     let expected_image =
         shared_test_helpers::read_image_from_fixture_file("stripe_sphere").unwrap();

--- a/tests/render_simple_world.rs
+++ b/tests/render_simple_world.rs
@@ -31,21 +31,21 @@ mod test_helpers {
     }
 
     pub fn create_simple_world_with_only_spheres() -> world::World {
-        let mut world = world::world();
+        let mut builder = world::WorldBuilder::new();
 
         // Create a floor and add it to the scene
-        {
+        builder.add_shape({
             let mut floor = shape::Shape::default_sphere();
             floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
             let mut material = material::material();
             material.color = color::color(1.0, 0.9, 0.9);
             material.specular = 0.0;
             floor.material = material;
-            world.shapes.push(floor);
-        }
+            floor
+        });
 
         // Create a wall and add it to the scene
-        {
+        builder.add_shape({
             let mut left_wall = shape::Shape::default_sphere();
             left_wall.set_transformation_matrix(
                 matrix::Matrix4::IDENTITY
@@ -58,11 +58,11 @@ mod test_helpers {
             material.color = color::color(1.0, 0.9, 0.9);
             material.specular = 0.0;
             left_wall.material = material;
-            world.shapes.push(left_wall);
-        }
+            left_wall
+        });
 
         // Create another wall and add it to the scene
-        {
+        builder.add_shape({
             let mut right_wall = shape::Shape::default_sphere();
             right_wall.set_transformation_matrix(
                 matrix::Matrix4::IDENTITY
@@ -75,11 +75,11 @@ mod test_helpers {
             material.color = color::color(1.0, 0.9, 0.9);
             material.specular = 0.0;
             right_wall.material = material;
-            world.shapes.push(right_wall);
-        }
+            right_wall
+        });
 
         // Add a sphere to the center
-        {
+        builder.add_shape({
             let mut middle = shape::Shape::default_sphere();
             middle.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-0.5, 1.0, 0.5));
             let mut material = material::material();
@@ -87,11 +87,11 @@ mod test_helpers {
             material.diffuse = 0.7;
             material.specular = 0.3;
             middle.material = material;
-            world.shapes.push(middle);
-        }
+            middle
+        });
 
         // Add a small green sphere on the right
-        {
+        builder.add_shape({
             let mut right = shape::Shape::default_sphere();
             right.set_transformation_matrix(
                 matrix::Matrix4::IDENTITY
@@ -103,11 +103,11 @@ mod test_helpers {
             material.diffuse = 0.7;
             material.specular = 0.3;
             right.material = material;
-            world.shapes.push(right);
-        }
+            right
+        });
 
         // Add a smaller green sphere on the left
-        {
+        builder.add_shape({
             let mut left = shape::Shape::default_sphere();
             left.set_transformation_matrix(
                 matrix::Matrix4::IDENTITY
@@ -119,33 +119,34 @@ mod test_helpers {
             material.diffuse = 0.7;
             material.specular = 0.3;
             left.material = material;
-            world.shapes.push(left);
-        }
+            left
+        });
 
         // Let there be light
-        let white_point_light =
-            lights::point_light(tuple::Point::new(-10.0, 10.0, -10.0), color::white());
-        world.light = Some(white_point_light);
+        builder.add_light_source(lights::point_light(
+            tuple::Point::new(-10.0, 10.0, -10.0),
+            color::white(),
+        ));
 
-        return world;
+        return builder.world;
     }
 
     pub fn create_simple_world_with_planes() -> world::World {
-        let mut world = world::world();
+        let mut builder = world::WorldBuilder::new();
 
         // Create a floor and add it to the scene
-        {
+        builder.add_shape({
             let mut floor = shape::Shape::default_plane();
             floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
             let mut material = material::material();
             material.color = color::color(1.0, 0.9, 0.9);
             material.specular = 0.0;
             floor.material = material;
-            world.shapes.push(floor);
-        }
+            floor
+        });
 
         // Add a sphere to the center
-        {
+        builder.add_shape({
             let mut middle = shape::Shape::default_sphere();
             middle.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-0.5, 1.0, 0.5));
             let mut material = material::material();
@@ -153,11 +154,11 @@ mod test_helpers {
             material.diffuse = 0.7;
             material.specular = 0.3;
             middle.material = material;
-            world.shapes.push(middle);
-        }
+            middle
+        });
 
         // Add a small green sphere on the right
-        {
+        builder.add_shape({
             let mut right = shape::Shape::default_sphere();
             right.set_transformation_matrix(
                 matrix::Matrix4::IDENTITY
@@ -169,11 +170,11 @@ mod test_helpers {
             material.diffuse = 0.7;
             material.specular = 0.3;
             right.material = material;
-            world.shapes.push(right);
-        }
+            right
+        });
 
         // Add a smaller green sphere on the left
-        {
+        builder.add_shape({
             let mut left = shape::Shape::default_sphere();
             left.set_transformation_matrix(
                 matrix::Matrix4::IDENTITY
@@ -185,22 +186,23 @@ mod test_helpers {
             material.diffuse = 0.7;
             material.specular = 0.3;
             left.material = material;
-            world.shapes.push(left);
-        }
+            left
+        });
 
         // Let there be light
-        let white_point_light =
-            lights::point_light(tuple::Point::new(-10.0, 10.0, -10.0), color::white());
-        world.light = Some(white_point_light);
+        builder.add_light_source(lights::point_light(
+            tuple::Point::new(-10.0, 10.0, -10.0),
+            color::white(),
+        ));
 
-        return world;
+        return builder.world;
     }
 
     pub fn create_checker_floor_world(reflective_floor: bool) -> world::World {
-        let mut world = world::world();
+        let mut builder = world::WorldBuilder::new();
 
         // Create a floor and add it to the scene
-        {
+        builder.add_shape({
             let mut floor = shape::Shape::default_plane();
             floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
 
@@ -214,11 +216,11 @@ mod test_helpers {
             pattern.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(0.1, 0.1, 0.1));
             material.pattern = Some(pattern);
             floor.material = material;
-            world.shapes.push(floor);
-        }
+            floor
+        });
 
         // Add a sphere to the center
-        {
+        builder.add_shape({
             let mut middle = shape::Shape::default_sphere();
             middle.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-0.5, 1.0, 0.5));
             let mut material = material::material();
@@ -226,15 +228,16 @@ mod test_helpers {
             material.diffuse = 0.7;
             material.specular = 0.3;
             middle.material = material;
-            world.shapes.push(middle);
-        }
+            middle
+        });
 
         // Let there be light
-        let white_point_light =
-            lights::point_light(tuple::Point::new(-10.0, 10.0, -10.0), color::white());
-        world.light = Some(white_point_light);
+        builder.add_light_source(lights::point_light(
+            tuple::Point::new(-10.0, 10.0, -10.0),
+            color::white(),
+        ));
 
-        return world;
+        return builder.world;
     }
 }
 


### PR DESCRIPTION
Worlds were being created via the modification of the `World` struct
directly. This meant that functions were aware of the implementation
details of the `World` struct would make the "multiple light sources"
TODO more difficult.

This commit introduces a new `WorldBuilder` struct which is intended to
contrain the adding of lights and the adding of shapes into an
interface.