### PR TITLE
Fix typos in `world` reflection test comment

### DIFF
--- a/src/world.rs
+++ b/src/world.rs
@@ -389,7 +389,7 @@ mod world_tests {
             tuple::Vector::new(0.0, 1.0, 0.0),
         );
 
-        // Without an addtional contraint light will bounce between these two planes indefinitly.
+        // Without an additional constraint light will bounce between these two planes indefinitely.
         // Our assertion is really: does this call terminate.
         let color = world.color_at(&ray, 10);
 


### PR DESCRIPTION
A comment in the indefinite-reflection test contained three misspellings: `addtional`, `contraint`, and `indefinitly`. Correct them to `additional`, `constraint`, and `indefinitely`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)