### PR TITLE
Update `rustfmt.toml` to the 2024 edition

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-edition = "2018"
+edition = "2024"


### PR DESCRIPTION
The crate moved to the Rust 2024 edition but `rustfmt.toml` still said 2018, so rustfmt was parsing the source as an older edition.

Bump it to match the crate edition. `cargo fmt --all -- --check` is clean before and after, so no reformatting results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)