### PR TITLE
Add a fluent `ShapeBuilder` for shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ a change that you expect to improve performance and know if it worked on not.
 
 ## Possible improvements
 
-- Builder interface for shapes.
-- Update setting of transformation matrices
-- Add a file input method for world description
-- Create animated gifs
+- A file format for describing whole scenes (camera, lights, shapes) —
+  distinct from the existing OBJ model importer (`obj_file`), which only
+  loads mesh geometry, not full scene descriptions.
+- Animated GIF output.

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -728,6 +728,172 @@ fn check_cap(ray: &ray::Ray, t: f64, radius: f64) -> bool {
     return x.powf(2.0) + z.powf(2.0) <= radius.powf(2.0);
 }
 
+// A fluent alternative to the `default_<shape>()` constructors, which need a
+// `let mut` binding plus separate `set_transformation_matrix`/`material`
+// statements to configure. Each `with_*`/`set_*` call consumes and returns
+// the builder so a shape can be built, transformed, and materialed in one
+// expression; `build()` unwraps the finished `Shape`.
+pub struct ShapeBuilder {
+    shape: Shape,
+}
+
+impl From<Shape> for ShapeBuilder {
+    // Resumes building an already-constructed shape, e.g. to set a
+    // transform on a shape assembled elsewhere (a group returned by a
+    // helper function, an OBJ model, ...).
+    fn from(shape: Shape) -> Self {
+        ShapeBuilder { shape }
+    }
+}
+
+impl ShapeBuilder {
+    pub fn sphere() -> Self {
+        ShapeBuilder {
+            shape: Shape::default_sphere(),
+        }
+    }
+
+    pub fn glass_sphere() -> Self {
+        ShapeBuilder {
+            shape: Shape::glass_sphere(),
+        }
+    }
+
+    pub fn plane() -> Self {
+        ShapeBuilder {
+            shape: Shape::default_plane(),
+        }
+    }
+
+    pub fn cube() -> Self {
+        ShapeBuilder {
+            shape: Shape::default_cube(),
+        }
+    }
+
+    pub fn cylinder(minimum: f64, maximum: f64, closed: bool) -> Self {
+        ShapeBuilder {
+            shape: Shape::cylinder(minimum, maximum, closed),
+        }
+    }
+
+    pub fn cone(minimum: f64, maximum: f64, closed: bool) -> Self {
+        ShapeBuilder {
+            shape: Shape::cone(minimum, maximum, closed),
+        }
+    }
+
+    pub fn group() -> Self {
+        ShapeBuilder {
+            shape: Shape::default_group(),
+        }
+    }
+
+    pub fn triangle(p1: tuple::Point, p2: tuple::Point, p3: tuple::Point) -> Self {
+        ShapeBuilder {
+            shape: Shape::triangle(p1, p2, p3),
+        }
+    }
+
+    pub fn smooth_triangle(
+        p1: tuple::Point,
+        p2: tuple::Point,
+        p3: tuple::Point,
+        n1: tuple::Vector,
+        n2: tuple::Vector,
+        n3: tuple::Vector,
+    ) -> Self {
+        ShapeBuilder {
+            shape: Shape::smooth_triangle(p1, p2, p3, n1, n2, n3),
+        }
+    }
+
+    pub fn csg(operation: CsgOperation, left: Shape, right: Shape) -> Self {
+        ShapeBuilder {
+            shape: Shape::csg(operation, left, right),
+        }
+    }
+
+    pub fn set_transform(mut self, transform: matrix::Matrix4) -> Self {
+        self.shape.transform = transform;
+        self
+    }
+
+    pub fn set_material(mut self, material: material::Material) -> Self {
+        self.shape.material = material;
+        self
+    }
+
+    pub fn add_child(mut self, child: Shape) -> Self {
+        self.shape.add_child(child);
+        self
+    }
+
+    pub fn build(self) -> Shape {
+        self.shape
+    }
+}
+
+#[cfg(test)]
+mod shape_builder_tests {
+    use crate::material;
+    use crate::matrix;
+    use crate::shape;
+    use crate::transformation::Transform;
+
+    fn blue_material() -> material::Material {
+        let mut material = material::material();
+        material.color = crate::color::color(0.2, 0.4, 1.0);
+        material
+    }
+
+    #[test]
+    fn test_building_a_shape_with_a_transform_and_material() {
+        let transform = matrix::Matrix4::IDENTITY.scaling(2.0, 2.0, 2.0);
+
+        let built = shape::ShapeBuilder::cube()
+            .set_transform(transform)
+            .set_material(blue_material())
+            .build();
+
+        let mut expected = shape::Shape::default_cube();
+        expected.set_transformation_matrix(transform);
+        expected.material = blue_material();
+        assert_eq!(built, expected);
+    }
+
+    #[test]
+    fn test_building_a_group_adds_children() {
+        let child = shape::Shape::default_sphere();
+        let built = shape::ShapeBuilder::group().add_child(child).build();
+
+        match &built.shape_type {
+            shape::ShapeType::Group { children } => assert_eq!(children.len(), 1),
+            _ => panic!("expected a group shape"),
+        }
+    }
+
+    #[test]
+    fn test_build_returns_defaults_when_unconfigured() {
+        let built = shape::ShapeBuilder::sphere().build();
+
+        assert_eq!(built, shape::Shape::default_sphere());
+    }
+
+    #[test]
+    fn test_from_shape_resumes_building_an_existing_shape() {
+        let transform = matrix::Matrix4::IDENTITY.translation(1.0, 2.0, 3.0);
+
+        let built = shape::ShapeBuilder::from(shape::Shape::default_sphere())
+            .set_transform(transform)
+            .build();
+
+        let mut expected = shape::Shape::default_sphere();
+        expected.set_transformation_matrix(transform);
+        assert_eq!(built, expected);
+    }
+}
+
 #[cfg(test)]
 mod sphere_tests {
     use crate::assert_tuple_approx_eq;

--- a/tests/render_basic_shapes_test.rs
+++ b/tests/render_basic_shapes_test.rs
@@ -42,16 +42,16 @@ fn test_simple_cube() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // A blue cube, rotated so three faces are visible.
-    builder.add_shape({
-        let mut cube = shape::Shape::default_cube();
-        cube.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY.rotation_y(std::f64::consts::PI / 6.0),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.2, 0.4, 1.0);
-        cube.material = material;
-        cube
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(matrix::Matrix4::IDENTITY.rotation_y(std::f64::consts::PI / 6.0))
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.2, 0.4, 1.0);
+                material
+            })
+            .build(),
+    );
 
     builder.add_light_source(lights::point_light(
         tuple::Point::new(-10.0, 10.0, -10.0),
@@ -76,13 +76,15 @@ fn test_simple_cylinder() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // A capped teal cylinder, seen from slightly above so the top cap shows.
-    builder.add_shape({
-        let mut cylinder = shape::Shape::cylinder(0.0, 2.0, true);
-        let mut material = material::material();
-        material.color = color::color(0.2, 0.7, 0.6);
-        cylinder.material = material;
-        cylinder
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cylinder(0.0, 2.0, true)
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.2, 0.7, 0.6);
+                material
+            })
+            .build(),
+    );
 
     builder.add_light_source(lights::point_light(
         tuple::Point::new(-10.0, 10.0, -10.0),
@@ -108,13 +110,15 @@ fn test_open_cylinder() -> Result<(), std::io::Error> {
 
     // An uncapped purple cylinder; the camera looks down into it, so the
     // hollow inside is visible.
-    builder.add_shape({
-        let mut cylinder = shape::Shape::cylinder(0.0, 2.0, false);
-        let mut material = material::material();
-        material.color = color::color(0.6, 0.3, 0.8);
-        cylinder.material = material;
-        cylinder
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cylinder(0.0, 2.0, false)
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.6, 0.3, 0.8);
+                material
+            })
+            .build(),
+    );
 
     builder.add_light_source(lights::point_light(
         tuple::Point::new(-10.0, 10.0, -10.0),
@@ -141,14 +145,16 @@ fn test_open_cone() -> Result<(), std::io::Error> {
     // An uncapped red cone with its tip at the bottom, opening upward like
     // a funnel; the camera looks down into the hollow inside. Squeezed in
     // `x` and `z` so the funnel is taller than it is wide.
-    builder.add_shape({
-        let mut cone = shape::Shape::cone(0.0, 1.0, false);
-        cone.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(0.5, 1.0, 0.5));
-        let mut material = material::material();
-        material.color = color::color(0.85, 0.3, 0.3);
-        cone.material = material;
-        cone
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cone(0.0, 1.0, false)
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(0.5, 1.0, 0.5))
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.85, 0.3, 0.3);
+                material
+            })
+            .build(),
+    );
 
     builder.add_light_source(lights::point_light(
         tuple::Point::new(-10.0, 10.0, -10.0),
@@ -174,14 +180,16 @@ fn test_simple_cone() -> Result<(), std::io::Error> {
 
     // An orange cone with its wide capped base at the bottom and its tip
     // pointing up.
-    builder.add_shape({
-        let mut cone = shape::Shape::cone(-1.0, 0.0, true);
-        cone.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(0.0, 1.0, 0.0));
-        let mut material = material::material();
-        material.color = color::color(0.9, 0.5, 0.2);
-        cone.material = material;
-        cone
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cone(-1.0, 0.0, true)
+            .set_transform(matrix::Matrix4::IDENTITY.translation(0.0, 1.0, 0.0))
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.9, 0.5, 0.2);
+                material
+            })
+            .build(),
+    );
 
     builder.add_light_source(lights::point_light(
         tuple::Point::new(-10.0, 10.0, -10.0),
@@ -206,14 +214,16 @@ fn test_simple_plane() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // A single matte plane stretching to the horizon.
-    builder.add_shape({
-        let mut plane = shape::Shape::default_plane();
-        let mut material = material::material();
-        material.color = color::color(0.4, 0.6, 0.9);
-        material.specular = 0.0;
-        plane.material = material;
-        plane
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::plane()
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.4, 0.6, 0.9);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     builder.add_light_source(lights::point_light(
         tuple::Point::new(-10.0, 10.0, -10.0),

--- a/tests/render_cover_test.rs
+++ b/tests/render_cover_test.rs
@@ -56,10 +56,10 @@ fn small_object() -> matrix::Matrix4 {
 }
 
 fn cube(color: color::Color, transform: matrix::Matrix4) -> shape::Shape {
-    let mut cube = shape::Shape::default_cube();
-    cube.material = cover_material(color);
-    cube.set_transformation_matrix(transform);
-    cube
+    shape::ShapeBuilder::cube()
+        .set_material(cover_material(color))
+        .set_transform(transform)
+        .build()
 }
 
 // The book's cover image, translated from the YAML scene description in
@@ -70,38 +70,42 @@ fn test_cover_scene() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // A white backdrop far behind the scene, lit only by its ambient term.
-    builder.add_shape({
-        let mut backdrop = shape::Shape::default_plane();
-        let mut material = material::material();
-        material.color = white();
-        material.ambient = 1.0;
-        material.diffuse = 0.0;
-        material.specular = 0.0;
-        backdrop.material = material;
-        backdrop.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .rotation_x(std::f64::consts::FRAC_PI_2)
-                .translation(0.0, 0.0, 500.0),
-        );
-        backdrop
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::plane()
+            .set_material({
+                let mut material = material::material();
+                material.color = white();
+                material.ambient = 1.0;
+                material.diffuse = 0.0;
+                material.specular = 0.0;
+                material
+            })
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .rotation_x(std::f64::consts::FRAC_PI_2)
+                    .translation(0.0, 0.0, 500.0),
+            )
+            .build(),
+    );
 
     // The glassy purple sphere sitting on top of the stack.
-    builder.add_shape({
-        let mut sphere = shape::Shape::default_sphere();
-        let mut material = material::material();
-        material.color = purple();
-        material.diffuse = 0.2;
-        material.ambient = 0.0;
-        material.specular = 1.0;
-        material.shininess = 200.0;
-        material.reflective = 0.7;
-        material.transparency = 0.7;
-        material.refractive_index = 1.5;
-        sphere.material = material;
-        sphere.set_transformation_matrix(large_object());
-        sphere
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_material({
+                let mut material = material::material();
+                material.color = purple();
+                material.diffuse = 0.2;
+                material.ambient = 0.0;
+                material.specular = 1.0;
+                material.shininess = 200.0;
+                material.reflective = 0.7;
+                material.transparency = 0.7;
+                material.refractive_index = 1.5;
+                material
+            })
+            .set_transform(large_object())
+            .build(),
+    );
 
     // The cascade of cubes, listed in the same order as the book.
     builder.add_shape(cube(white(), medium_object().translation(4.0, 0.0, 0.0)));

--- a/tests/render_csg_test.rs
+++ b/tests/render_csg_test.rs
@@ -22,76 +22,93 @@ fn test_csg_scene() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // The floor.
-    builder.add_shape({
-        let mut floor = shape::Shape::default_plane();
-        let mut material = material::material();
-        material.color = color::color(0.9, 0.85, 0.8);
-        material.specular = 0.0;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::plane()
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.9, 0.85, 0.8);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     // The lens: the intersection of two overlapping spheres, turned so both
     // faces are visible. Each face keeps the color of its sphere.
     builder.add_shape({
-        let mut left_half = shape::Shape::default_sphere();
-        left_half.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-0.4, 0.0, 0.0));
-        let mut left_material = material::material();
-        left_material.color = color::color(0.2, 0.6, 0.4);
-        left_material.specular = 0.4;
-        left_half.material = left_material;
+        let left_half = shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.translation(-0.4, 0.0, 0.0))
+            .set_material({
+                let mut left_material = material::material();
+                left_material.color = color::color(0.2, 0.6, 0.4);
+                left_material.specular = 0.4;
+                left_material
+            })
+            .build();
 
-        let mut right_half = shape::Shape::default_sphere();
-        right_half.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(0.4, 0.0, 0.0));
-        let mut right_material = material::material();
-        right_material.color = color::color(0.3, 0.5, 0.8);
-        right_material.specular = 0.4;
-        right_half.material = right_material;
+        let right_half = shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.translation(0.4, 0.0, 0.0))
+            .set_material({
+                let mut right_material = material::material();
+                right_material.color = color::color(0.3, 0.5, 0.8);
+                right_material.specular = 0.4;
+                right_material
+            })
+            .build();
 
-        let mut lens = shape::Shape::csg(shape::CsgOperation::Intersection, left_half, right_half);
-        lens.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .rotation_y(0.1)
-                .translation(-2.2, 0.92, 0.8),
-        );
-        lens
+        shape::ShapeBuilder::csg(shape::CsgOperation::Intersection, left_half, right_half)
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .rotation_y(0.1)
+                    .translation(-2.2, 0.92, 0.8),
+            )
+            .build()
     });
 
     // The carved cube: an oversized red sphere subtracted from a yellow
     // cube, hollowing a red dish out of each face.
     builder.add_shape({
-        let mut cube = shape::Shape::default_cube();
-        let mut cube_material = material::material();
-        cube_material.color = color::color(1.0, 0.85, 0.2);
-        cube_material.specular = 0.3;
-        cube.material = cube_material;
+        let cube = shape::ShapeBuilder::cube()
+            .set_material({
+                let mut cube_material = material::material();
+                cube_material.color = color::color(1.0, 0.85, 0.2);
+                cube_material.specular = 0.3;
+                cube_material
+            })
+            .build();
 
-        let mut scoop = shape::Shape::default_sphere();
-        scoop.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(1.35, 1.35, 1.35));
-        let mut scoop_material = material::material();
-        scoop_material.color = color::color(0.9, 0.2, 0.2);
-        scoop_material.specular = 0.3;
-        scoop.material = scoop_material;
+        let scoop = shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(1.35, 1.35, 1.35))
+            .set_material({
+                let mut scoop_material = material::material();
+                scoop_material.color = color::color(0.9, 0.2, 0.2);
+                scoop_material.specular = 0.3;
+                scoop_material
+            })
+            .build();
 
-        let mut carved = shape::Shape::csg(shape::CsgOperation::Difference, cube, scoop);
-        carved.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .rotation_y(0.6)
-                .translation(0.0, 1.0, 1.5),
-        );
-        carved
+        shape::ShapeBuilder::csg(shape::CsgOperation::Difference, cube, scoop)
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .rotation_y(0.6)
+                    .translation(0.0, 1.0, 1.5),
+            )
+            .build()
     });
 
     // Saturn: the ring is one flat capped cylinder minus a slightly wider
     // one punched through its middle, and a union joins it to the planet so
     // the whole thing is a single tilted shape.
     builder.add_shape({
-        let mut planet = shape::Shape::default_sphere();
-        planet.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(0.8, 0.8, 0.8));
-        let mut planet_material = material::material();
-        planet_material.color = color::color(0.9, 0.7, 0.4);
-        planet_material.specular = 0.2;
-        planet.material = planet_material;
+        let planet = shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(0.8, 0.8, 0.8))
+            .set_material({
+                let mut planet_material = material::material();
+                planet_material.color = color::color(0.9, 0.7, 0.4);
+                planet_material.specular = 0.2;
+                planet_material
+            })
+            .build();
 
         fn ring_material() -> material::Material {
             let mut material = material::material();
@@ -100,24 +117,26 @@ fn test_csg_scene() -> Result<(), std::io::Error> {
             material
         }
 
-        let mut disc = shape::Shape::cylinder(-0.5, 0.5, true);
-        disc.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(1.6, 0.06, 1.6));
-        disc.material = ring_material();
+        let disc = shape::ShapeBuilder::cylinder(-0.5, 0.5, true)
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(1.6, 0.06, 1.6))
+            .set_material(ring_material())
+            .build();
 
-        let mut hole = shape::Shape::cylinder(-0.5, 0.5, true);
-        hole.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(1.1, 0.3, 1.1));
-        hole.material = ring_material();
+        let hole = shape::ShapeBuilder::cylinder(-0.5, 0.5, true)
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(1.1, 0.3, 1.1))
+            .set_material(ring_material())
+            .build();
 
         let ring = shape::Shape::csg(shape::CsgOperation::Difference, disc, hole);
 
-        let mut saturn = shape::Shape::csg(shape::CsgOperation::Union, planet, ring);
-        saturn.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .rotation_x(-0.5)
-                .rotation_z(-0.3)
-                .translation(2.1, 1.5, 1.5),
-        );
-        saturn
+        shape::ShapeBuilder::csg(shape::CsgOperation::Union, planet, ring)
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .rotation_x(-0.5)
+                    .rotation_z(-0.3)
+                    .translation(2.1, 1.5, 1.5),
+            )
+            .build()
     });
 
     builder.add_light_source(lights::point_light(

--- a/tests/render_cubes_test.rs
+++ b/tests/render_cubes_test.rs
@@ -18,136 +18,154 @@ fn test_cube_scene() -> Result<(), std::io::Error> {
 
     // The room: one big cube. The floor is at y = 0 because the cube is
     // scaled to 15 and lifted by 15.
-    builder.add_shape({
-        let mut room = shape::Shape::default_cube();
-        room.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(15.0, 15.0, 15.0)
-                .translation(0.0, 15.0, 0.0),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.9, 0.85, 0.8);
-        material.specular = 0.0;
-        room.material = material;
-        room
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(15.0, 15.0, 15.0)
+                    .translation(0.0, 15.0, 0.0),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.9, 0.85, 0.8);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     // The table top.
-    builder.add_shape({
-        let mut top = shape::Shape::default_cube();
-        top.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(1.5, 0.05, 1.0)
-                .translation(0.0, 1.0, 0.0),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.55, 0.35, 0.2);
-        material.specular = 0.3;
-        top.material = material;
-        top
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(1.5, 0.05, 1.0)
+                    .translation(0.0, 1.0, 0.0),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.55, 0.35, 0.2);
+                material.specular = 0.3;
+                material
+            })
+            .build(),
+    );
 
     // The table legs: tall thin cubes under each corner of the top.
-    builder.add_shape({
-        let mut leg = shape::Shape::default_cube();
-        leg.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.05, 0.5, 0.05)
-                .translation(-1.3, 0.5, -0.8),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.55, 0.35, 0.2);
-        material.specular = 0.3;
-        leg.material = material;
-        leg
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.05, 0.5, 0.05)
+                    .translation(-1.3, 0.5, -0.8),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.55, 0.35, 0.2);
+                material.specular = 0.3;
+                material
+            })
+            .build(),
+    );
 
-    builder.add_shape({
-        let mut leg = shape::Shape::default_cube();
-        leg.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.05, 0.5, 0.05)
-                .translation(-1.3, 0.5, 0.8),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.55, 0.35, 0.2);
-        material.specular = 0.3;
-        leg.material = material;
-        leg
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.05, 0.5, 0.05)
+                    .translation(-1.3, 0.5, 0.8),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.55, 0.35, 0.2);
+                material.specular = 0.3;
+                material
+            })
+            .build(),
+    );
 
-    builder.add_shape({
-        let mut leg = shape::Shape::default_cube();
-        leg.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.05, 0.5, 0.05)
-                .translation(1.3, 0.5, -0.8),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.55, 0.35, 0.2);
-        material.specular = 0.3;
-        leg.material = material;
-        leg
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.05, 0.5, 0.05)
+                    .translation(1.3, 0.5, -0.8),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.55, 0.35, 0.2);
+                material.specular = 0.3;
+                material
+            })
+            .build(),
+    );
 
-    builder.add_shape({
-        let mut leg = shape::Shape::default_cube();
-        leg.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.05, 0.5, 0.05)
-                .translation(1.3, 0.5, 0.8),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.55, 0.35, 0.2);
-        material.specular = 0.3;
-        leg.material = material;
-        leg
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.05, 0.5, 0.05)
+                    .translation(1.3, 0.5, 0.8),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.55, 0.35, 0.2);
+                material.specular = 0.3;
+                material
+            })
+            .build(),
+    );
 
     // A small red box sitting on the table, turned slightly.
-    builder.add_shape({
-        let mut small_box = shape::Shape::default_cube();
-        small_box.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.15, 0.15, 0.15)
-                .rotation_y(0.5)
-                .translation(0.4, 1.2, 0.2),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.8, 0.2, 0.2);
-        small_box.material = material;
-        small_box
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.15, 0.15, 0.15)
+                    .rotation_y(0.5)
+                    .translation(0.4, 1.2, 0.2),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.8, 0.2, 0.2);
+                material
+            })
+            .build(),
+    );
 
     // A green box on the floor, left of the table.
-    builder.add_shape({
-        let mut floor_box = shape::Shape::default_cube();
-        floor_box.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.35, 0.35, 0.35)
-                .rotation_y(0.3)
-                .translation(-2.7, 0.35, -1.4),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.2, 0.6, 0.3);
-        floor_box.material = material;
-        floor_box
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.35, 0.35, 0.35)
+                    .rotation_y(0.3)
+                    .translation(-2.7, 0.35, -1.4),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.2, 0.6, 0.3);
+                material
+            })
+            .build(),
+    );
 
     // A blue box on the floor, in front of the table.
-    builder.add_shape({
-        let mut floor_box = shape::Shape::default_cube();
-        floor_box.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.2, 0.2, 0.2)
-                .rotation_y(-0.4)
-                .translation(1.2, 0.2, -1.8),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.25, 0.35, 0.8);
-        floor_box.material = material;
-        floor_box
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.2, 0.2, 0.2)
+                    .rotation_y(-0.4)
+                    .translation(1.2, 0.2, -1.8),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.25, 0.35, 0.8);
+                material
+            })
+            .build(),
+    );
 
     builder.add_light_source(lights::point_light(
         tuple::Point::new(-6.0, 8.0, -8.0),

--- a/tests/render_cylinders_test.rs
+++ b/tests/render_cylinders_test.rs
@@ -18,76 +18,86 @@ fn test_cylinder_scene() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // The floor.
-    builder.add_shape({
-        let mut floor = shape::Shape::default_plane();
-        let mut material = material::material();
-        material.color = color::color(0.9, 0.85, 0.8);
-        material.specular = 0.0;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::plane()
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.9, 0.85, 0.8);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     // A solid green column: a capped unit-height cylinder.
-    builder.add_shape({
-        let mut column = shape::Shape::cylinder(0.0, 1.0, true);
-        column.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.5, 1.0, 0.5)
-                .translation(-1.5, 0.0, 0.5),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.2, 0.6, 0.4);
-        material.specular = 0.3;
-        column.material = material;
-        column
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cylinder(0.0, 1.0, true)
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.5, 1.0, 0.5)
+                    .translation(-1.5, 0.0, 0.5),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.2, 0.6, 0.4);
+                material.specular = 0.3;
+                material
+            })
+            .build(),
+    );
 
     // An open yellow pipe; the camera looks down into it, so the hollow
     // inside is visible.
-    builder.add_shape({
-        let mut pipe = shape::Shape::cylinder(0.0, 1.0, false);
-        pipe.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.35, 1.4, 0.35)
-                .translation(1.6, 0.0, 1.0),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.8, 0.7, 0.3);
-        material.specular = 0.3;
-        pipe.material = material;
-        pipe
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cylinder(0.0, 1.0, false)
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.35, 1.4, 0.35)
+                    .translation(1.6, 0.0, 1.0),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.8, 0.7, 0.3);
+                material.specular = 0.3;
+                material
+            })
+            .build(),
+    );
 
     // The waffle cone: the upper half of a cone opens upward, leaving the
     // tip resting on the floor.
-    builder.add_shape({
-        let mut waffle_cone = shape::Shape::cone(0.0, 1.0, false);
-        waffle_cone.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.5, 1.5, 0.5)
-                .translation(0.0, 0.0, -0.5),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.8, 0.6, 0.4);
-        material.specular = 0.2;
-        waffle_cone.material = material;
-        waffle_cone
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cone(0.0, 1.0, false)
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.5, 1.5, 0.5)
+                    .translation(0.0, 0.0, -0.5),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.8, 0.6, 0.4);
+                material.specular = 0.2;
+                material
+            })
+            .build(),
+    );
 
     // The strawberry scoop, overlapping the cone's rim.
-    builder.add_shape({
-        let mut scoop = shape::Shape::default_sphere();
-        scoop.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.6, 0.6, 0.6)
-                .translation(0.0, 1.6, -0.5),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.9, 0.5, 0.6);
-        material.specular = 0.4;
-        scoop.material = material;
-        scoop
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.6, 0.6, 0.6)
+                    .translation(0.0, 1.6, -0.5),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.9, 0.5, 0.6);
+                material.specular = 0.4;
+                material
+            })
+            .build(),
+    );
 
     builder.add_light_source(lights::point_light(
         tuple::Point::new(-6.0, 8.0, -8.0),

--- a/tests/render_dice_test.rs
+++ b/tests/render_dice_test.rs
@@ -62,23 +62,26 @@ fn pip_positions() -> Vec<(f64, f64, f64)> {
 // round the corners off, then a difference for each pip, carving a dish
 // that keeps the pip's own color.
 fn die(body_color: color::Color, pip_color: color::Color) -> shape::Shape {
-    let mut cube = shape::Shape::default_cube();
-    cube.material = colored_material(body_color);
+    let cube = shape::ShapeBuilder::cube()
+        .set_material(colored_material(body_color))
+        .build();
 
-    let mut corners = shape::Shape::default_sphere();
-    corners.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(1.6, 1.6, 1.6));
-    corners.material = colored_material(body_color);
+    let corners = shape::ShapeBuilder::sphere()
+        .set_transform(matrix::Matrix4::IDENTITY.scaling(1.6, 1.6, 1.6))
+        .set_material(colored_material(body_color))
+        .build();
 
     let mut die = shape::Shape::csg(shape::CsgOperation::Intersection, cube, corners);
 
     for (x, y, z) in pip_positions() {
-        let mut pip = shape::Shape::default_sphere();
-        pip.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.22, 0.22, 0.22)
-                .translation(x, y, z),
-        );
-        pip.material = pip_material(pip_color);
+        let pip = shape::ShapeBuilder::sphere()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.22, 0.22, 0.22)
+                    .translation(x, y, z),
+            )
+            .set_material(pip_material(pip_color))
+            .build();
         die = shape::Shape::csg(shape::CsgOperation::Difference, die, pip);
     }
     return die;
@@ -92,46 +95,48 @@ fn test_dice_scene() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // The felt.
-    builder.add_shape({
-        let mut floor = shape::Shape::default_plane();
-        let mut material = material::material();
-        material.color = color::color(0.15, 0.45, 0.25);
-        material.specular = 0.0;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::plane()
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.15, 0.45, 0.25);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     // An ivory die with dark pips, showing one on top.
-    builder.add_shape({
-        let mut ivory_die = die(
+    builder.add_shape(
+        shape::ShapeBuilder::from(die(
             color::color(0.95, 0.93, 0.85),
             color::color(0.15, 0.15, 0.18),
-        );
-        ivory_die.set_transformation_matrix(
+        ))
+        .set_transform(
             matrix::Matrix4::IDENTITY
                 .scaling(0.7, 0.7, 0.7)
                 .rotation_y(-0.4)
                 .translation(-1.3, 0.7, 0.2),
-        );
-        ivory_die
-    });
+        )
+        .build(),
+    );
 
     // A red die with white pips, tipped a quarter turn onto its side so
     // three is up, then spun a little.
-    builder.add_shape({
-        let mut red_die = die(
+    builder.add_shape(
+        shape::ShapeBuilder::from(die(
             color::color(0.75, 0.15, 0.18),
             color::color(0.95, 0.95, 0.95),
-        );
-        red_die.set_transformation_matrix(
+        ))
+        .set_transform(
             matrix::Matrix4::IDENTITY
                 .scaling(0.7, 0.7, 0.7)
                 .rotation_z(std::f64::consts::FRAC_PI_2)
                 .rotation_y(0.5)
                 .translation(1.2, 0.7, -0.4),
-        );
-        red_die
-    });
+        )
+        .build(),
+    );
 
     builder.add_light_source(lights::point_light(
         tuple::Point::new(-6.0, 8.0, -8.0),

--- a/tests/render_hexagon_test.rs
+++ b/tests/render_hexagon_test.rs
@@ -49,46 +49,47 @@ fn hexagon_material() -> material::Material {
 }
 
 fn hexagon_corner() -> shape::Shape {
-    let mut corner = shape::Shape::default_sphere();
-    corner.set_transformation_matrix(
-        matrix::Matrix4::IDENTITY
-            .scaling(0.25, 0.25, 0.25)
-            .translation(0.0, 0.0, -1.0),
-    );
-    corner.material = hexagon_material();
-    return corner;
+    shape::ShapeBuilder::sphere()
+        .set_transform(
+            matrix::Matrix4::IDENTITY
+                .scaling(0.25, 0.25, 0.25)
+                .translation(0.0, 0.0, -1.0),
+        )
+        .set_material(hexagon_material())
+        .build()
 }
 
 fn hexagon_edge() -> shape::Shape {
-    let mut edge = shape::Shape::cylinder(0.0, 1.0, false);
-    edge.set_transformation_matrix(
-        matrix::Matrix4::IDENTITY
-            .scaling(0.25, 1.0, 0.25)
-            .rotation_z(-std::f64::consts::PI / 2.0)
-            .rotation_y(-std::f64::consts::PI / 6.0)
-            .translation(0.0, 0.0, -1.0),
-    );
-    edge.material = hexagon_material();
-    return edge;
+    shape::ShapeBuilder::cylinder(0.0, 1.0, false)
+        .set_transform(
+            matrix::Matrix4::IDENTITY
+                .scaling(0.25, 1.0, 0.25)
+                .rotation_z(-std::f64::consts::PI / 2.0)
+                .rotation_y(-std::f64::consts::PI / 6.0)
+                .translation(0.0, 0.0, -1.0),
+        )
+        .set_material(hexagon_material())
+        .build()
 }
 
 fn hexagon_side() -> shape::Shape {
-    let mut side = shape::Shape::default_group();
-    side.add_child(hexagon_corner());
-    side.add_child(hexagon_edge());
-    return side;
+    shape::ShapeBuilder::group()
+        .add_child(hexagon_corner())
+        .add_child(hexagon_edge())
+        .build()
 }
 
 fn hexagon() -> shape::Shape {
-    let mut hexagon = shape::Shape::default_group();
+    let mut hexagon = shape::ShapeBuilder::group();
     for n in 0..6 {
-        let mut side = hexagon_side();
-        side.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY.rotation_y(n as f64 * std::f64::consts::PI / 3.0),
-        );
-        hexagon.add_child(side);
+        let side = shape::ShapeBuilder::from(hexagon_side())
+            .set_transform(
+                matrix::Matrix4::IDENTITY.rotation_y(n as f64 * std::f64::consts::PI / 3.0),
+            )
+            .build();
+        hexagon = hexagon.add_child(side);
     }
-    return hexagon;
+    return hexagon.build();
 }
 
 #[test]
@@ -96,26 +97,28 @@ fn test_hexagon() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // A matte white floor to catch the hexagon's shadow.
-    builder.add_shape({
-        let mut floor = shape::Shape::default_plane();
-        let mut material = material::material();
-        material.color = color::color(1.0, 1.0, 1.0);
-        material.specular = 0.0;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::plane()
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(1.0, 1.0, 1.0);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     // The whole hexagon is lifted and tipped forward with a single
     // transform on the outermost group.
-    builder.add_shape({
-        let mut hexagon = hexagon();
-        hexagon.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .rotation_x(-std::f64::consts::PI / 6.0)
-                .translation(0.0, 1.2, 0.0),
-        );
-        hexagon
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::from(hexagon())
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .rotation_x(-std::f64::consts::PI / 6.0)
+                    .translation(0.0, 1.2, 0.0),
+            )
+            .build(),
+    );
 
     builder.add_light_source(lights::point_light(
         tuple::Point::new(-6.0, 8.0, -8.0),

--- a/tests/render_multiple_lights_test.rs
+++ b/tests/render_multiple_lights_test.rs
@@ -42,24 +42,28 @@ fn test_multiple_lights() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // A matte white floor to catch the shadows.
-    builder.add_shape({
-        let mut floor = shape::Shape::default_plane();
-        let mut material = material::material();
-        material.color = color::color(1.0, 1.0, 1.0);
-        material.specular = 0.0;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::plane()
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(1.0, 1.0, 1.0);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     // A white sphere lit from both sides.
-    builder.add_shape({
-        let mut sphere = shape::Shape::default_sphere();
-        sphere.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(0.0, 1.0, 0.0));
-        let mut material = material::material();
-        material.color = color::color(0.9, 0.9, 0.9);
-        sphere.material = material;
-        sphere
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.translation(0.0, 1.0, 0.0))
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.9, 0.9, 0.9);
+                material
+            })
+            .build(),
+    );
 
     // A warm light from the left and a cool light from the right. Each casts
     // its own shadow, tinted by the opposite light's color.

--- a/tests/render_obj_models_test.rs
+++ b/tests/render_obj_models_test.rs
@@ -47,14 +47,16 @@ fn load_model(path: &str) -> Result<shape::Shape, std::io::Error> {
 fn render_model(model: shape::Shape, from: tuple::Point, to: tuple::Point) -> canvas::Canvas {
     let mut builder = world::WorldBuilder::new();
 
-    builder.add_shape({
-        let mut floor = shape::Shape::default_plane();
-        let mut material = material::material();
-        material.color = color::color(0.55, 0.6, 0.65);
-        material.specular = 0.0;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::plane()
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.55, 0.6, 0.65);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     builder.add_shape(model);
 
@@ -76,14 +78,15 @@ fn render_model(model: shape::Shape, from: tuple::Point, to: tuple::Point) -> ca
 // interpolating the vertex normals to hide the low polygon count.
 #[test]
 fn test_low_poly_teapot() -> Result<(), std::io::Error> {
-    let mut teapot = load_model("object_files/teapot-low.obj")?;
     // The model is built z-up and roughly 32 units wide, so stand it up on
     // the y axis and scale it down to about three units across.
-    teapot.set_transformation_matrix(
-        matrix::Matrix4::IDENTITY
-            .rotation_x(-std::f64::consts::PI / 2.0)
-            .scaling(0.1, 0.1, 0.1),
-    );
+    let teapot = shape::ShapeBuilder::from(load_model("object_files/teapot-low.obj")?)
+        .set_transform(
+            matrix::Matrix4::IDENTITY
+                .rotation_x(-std::f64::consts::PI / 2.0)
+                .scaling(0.1, 0.1, 0.1),
+        )
+        .build();
 
     let canvas = render_model(
         teapot,
@@ -99,12 +102,13 @@ fn test_low_poly_teapot() -> Result<(), std::io::Error> {
 // but the silhouette and the lid seam get much cleaner.
 #[test]
 fn test_high_poly_teapot() -> Result<(), std::io::Error> {
-    let mut teapot = load_model("object_files/teapot.obj")?;
-    teapot.set_transformation_matrix(
-        matrix::Matrix4::IDENTITY
-            .rotation_x(-std::f64::consts::PI / 2.0)
-            .scaling(0.1, 0.1, 0.1),
-    );
+    let teapot = shape::ShapeBuilder::from(load_model("object_files/teapot.obj")?)
+        .set_transform(
+            matrix::Matrix4::IDENTITY
+                .rotation_x(-std::f64::consts::PI / 2.0)
+                .scaling(0.1, 0.1, 0.1),
+        )
+        .build();
 
     let canvas = render_model(
         teapot,
@@ -120,14 +124,15 @@ fn test_high_poly_teapot() -> Result<(), std::io::Error> {
 // teapots every facet is visible.
 #[test]
 fn test_cow() -> Result<(), std::io::Error> {
-    let mut cow = load_model("object_files/cow-nonormals.obj")?;
     // The model is y-up, about 10 units long, facing +x, with its hooves at
     // y=-3.64: shrink it and lift it onto the floor.
-    cow.set_transformation_matrix(
-        matrix::Matrix4::IDENTITY
-            .scaling(0.25, 0.25, 0.25)
-            .translation(-0.2, 0.91, 0.0),
-    );
+    let cow = shape::ShapeBuilder::from(load_model("object_files/cow-nonormals.obj")?)
+        .set_transform(
+            matrix::Matrix4::IDENTITY
+                .scaling(0.25, 0.25, 0.25)
+                .translation(-0.2, 0.91, 0.0),
+        )
+        .build();
 
     let canvas = render_model(
         cow,
@@ -142,16 +147,17 @@ fn test_cow() -> Result<(), std::io::Error> {
 // A teddy bear of 3,192 flat triangles without vertex normals.
 #[test]
 fn test_teddy() -> Result<(), std::io::Error> {
-    let mut teddy = load_model("object_files/teddy.obj")?;
     // The model is y-up and centered on the origin, about 42 units tall,
     // facing -z: turn it around to face the camera, then shrink it and
     // lift it onto the floor.
-    teddy.set_transformation_matrix(
-        matrix::Matrix4::IDENTITY
-            .rotation_y(std::f64::consts::PI)
-            .scaling(0.05, 0.05, 0.05)
-            .translation(0.0, 1.05, 0.0),
-    );
+    let teddy = shape::ShapeBuilder::from(load_model("object_files/teddy.obj")?)
+        .set_transform(
+            matrix::Matrix4::IDENTITY
+                .rotation_y(std::f64::consts::PI)
+                .scaling(0.05, 0.05, 0.05)
+                .translation(0.0, 1.05, 0.0),
+        )
+        .build();
 
     let canvas = render_model(
         teddy,

--- a/tests/render_pattern_test.rs
+++ b/tests/render_pattern_test.rs
@@ -14,59 +14,65 @@ fn test_checkered_sphere() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // Create a floor and add it to the scene
-    builder.add_shape({
-        let mut floor = shape::Shape::default_sphere();
-        floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
-        let mut material = material::material();
-        material.color = color::color(1.0, 0.9, 0.9);
-        material.specular = 0.0;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0))
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(1.0, 0.9, 0.9);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere to the left
-    builder.add_shape({
-        let mut left = shape::Shape::default_sphere();
-        left.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-1.5, 1.0, 0.5));
-        // Scaled down so several cells are visible on the sphere, and nudged
-        // so cell boundaries don't land exactly on the sphere's poles.
-        let mut pattern = patterns::Pattern::checkers(color::black(), color::white());
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.4, 0.4, 0.4)
-                .translation(0.01, 0.01, 0.01),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        left.material = material;
-        left
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.translation(-1.5, 1.0, 0.5))
+            .set_material({
+                // Scaled down so several cells are visible on the sphere, and nudged
+                // so cell boundaries don't land exactly on the sphere's poles.
+                let mut pattern = patterns::Pattern::checkers(color::black(), color::white());
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.4, 0.4, 0.4)
+                        .translation(0.01, 0.01, 0.01),
+                );
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere to the right
-    builder.add_shape({
-        let mut right = shape::Shape::default_sphere();
-        right.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .rotation_z(std::f64::consts::PI / 2.0)
-                .translation(1.5, 1.0, 0.5),
-        );
-        let mut pattern = patterns::Pattern::checkers(color::black(), color::white());
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.4, 0.4, 0.4)
-                .translation(0.01, 0.01, 0.01),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        right.material = material;
-        right
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .rotation_z(std::f64::consts::PI / 2.0)
+                    .translation(1.5, 1.0, 0.5),
+            )
+            .set_material({
+                let mut pattern = patterns::Pattern::checkers(color::black(), color::white());
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.4, 0.4, 0.4)
+                        .translation(0.01, 0.01, 0.01),
+                );
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Let there be light
     builder.add_light_source(lights::point_light(
@@ -101,59 +107,65 @@ fn test_gradient_sphere() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // Create a floor and add it to the scene
-    builder.add_shape({
-        let mut floor = shape::Shape::default_sphere();
-        floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
-        let mut material = material::material();
-        material.color = color::color(1.0, 0.9, 0.9);
-        material.specular = 0.0;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0))
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(1.0, 0.9, 0.9);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere to the left
-    builder.add_shape({
-        let mut left = shape::Shape::default_sphere();
-        left.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-1.5, 1.0, 0.5));
-        // Stretched and shifted so a single smooth black-to-white ramp spans
-        // the sphere instead of the pattern wrapping at x = 0.
-        let mut pattern = patterns::Pattern::gradient(color::black(), color::white());
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(2.02, 2.02, 2.02)
-                .translation(-1.01, 0.0, 0.0),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        left.material = material;
-        left
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.translation(-1.5, 1.0, 0.5))
+            .set_material({
+                // Stretched and shifted so a single smooth black-to-white ramp spans
+                // the sphere instead of the pattern wrapping at x = 0.
+                let mut pattern = patterns::Pattern::gradient(color::black(), color::white());
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(2.02, 2.02, 2.02)
+                        .translation(-1.01, 0.0, 0.0),
+                );
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere to the right
-    builder.add_shape({
-        let mut right = shape::Shape::default_sphere();
-        right.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .rotation_z(std::f64::consts::PI / 2.0)
-                .translation(1.5, 1.0, 0.5),
-        );
-        let mut pattern = patterns::Pattern::gradient(color::black(), color::white());
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(2.02, 2.02, 2.02)
-                .translation(-1.01, 0.0, 0.0),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        right.material = material;
-        right
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .rotation_z(std::f64::consts::PI / 2.0)
+                    .translation(1.5, 1.0, 0.5),
+            )
+            .set_material({
+                let mut pattern = patterns::Pattern::gradient(color::black(), color::white());
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(2.02, 2.02, 2.02)
+                        .translation(-1.01, 0.0, 0.0),
+                );
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Let there be light
     builder.add_light_source(lights::point_light(
@@ -188,56 +200,62 @@ fn test_ring_sphere() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // Create a floor and add it to the scene
-    builder.add_shape({
-        let mut floor = shape::Shape::default_sphere();
-        floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
-        let mut material = material::material();
-        material.color = color::color(1.0, 0.9, 0.9);
-        material.specular = 0.0;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0))
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(1.0, 0.9, 0.9);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere to the left
-    builder.add_shape({
-        let mut left = shape::Shape::default_sphere();
-        left.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-1.5, 1.0, 0.5));
-        // Scaled down so several rings fit on the sphere, and rotated so
-        // the rings' axis points at the camera, showing a bullseye
-        let mut pattern = patterns::Pattern::ring(color::black(), color::white());
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.2, 0.2, 0.2)
-                .rotation_x(std::f64::consts::PI / 2.0),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        left.material = material;
-        left
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.translation(-1.5, 1.0, 0.5))
+            .set_material({
+                // Scaled down so several rings fit on the sphere, and rotated so
+                // the rings' axis points at the camera, showing a bullseye
+                let mut pattern = patterns::Pattern::ring(color::black(), color::white());
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.2, 0.2, 0.2)
+                        .rotation_x(std::f64::consts::PI / 2.0),
+                );
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere to the right
-    builder.add_shape({
-        let mut right = shape::Shape::default_sphere();
-        right.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(1.5, 1.0, 0.5));
-        // A wider bullseye than the sphere on the left
-        let mut pattern = patterns::Pattern::ring(color::black(), color::white());
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.25, 0.25, 0.25)
-                .rotation_x(std::f64::consts::PI / 2.0),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        right.material = material;
-        right
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.translation(1.5, 1.0, 0.5))
+            .set_material({
+                // A wider bullseye than the sphere on the left
+                let mut pattern = patterns::Pattern::ring(color::black(), color::white());
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.25, 0.25, 0.25)
+                        .rotation_x(std::f64::consts::PI / 2.0),
+                );
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Let there be light
     builder.add_light_source(lights::point_light(
@@ -271,65 +289,71 @@ fn test_checkered_cube() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // Create a floor and add it to the scene
-    builder.add_shape({
-        let mut floor = shape::Shape::default_sphere();
-        floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
-        let mut material = material::material();
-        material.color = color::color(1.0, 0.9, 0.9);
-        material.specular = 0.0;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0))
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(1.0, 0.9, 0.9);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     // Add a cube to the left. The pattern is scaled and nudged so cell
     // boundaries don't land exactly on the cube faces (float noise there
     // renders differently on macOS and Linux).
-    builder.add_shape({
-        let mut left = shape::Shape::default_cube();
-        left.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.7, 0.7, 0.7)
-                .rotation_y(std::f64::consts::PI / 6.0)
-                .translation(-1.5, 0.7, 0.5),
-        );
-        let mut pattern = patterns::Pattern::checkers(color::black(), color::white());
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.45, 0.45, 0.45)
-                .translation(0.01, 0.01, 0.01),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        left.material = material;
-        left
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.7, 0.7, 0.7)
+                    .rotation_y(std::f64::consts::PI / 6.0)
+                    .translation(-1.5, 0.7, 0.5),
+            )
+            .set_material({
+                let mut pattern = patterns::Pattern::checkers(color::black(), color::white());
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.45, 0.45, 0.45)
+                        .translation(0.01, 0.01, 0.01),
+                );
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Add a cube to the right, rotated the other way
-    builder.add_shape({
-        let mut right = shape::Shape::default_cube();
-        right.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.7, 0.7, 0.7)
-                .rotation_y(-std::f64::consts::PI / 5.0)
-                .translation(1.5, 0.7, 0.5),
-        );
-        let mut pattern = patterns::Pattern::checkers(color::black(), color::white());
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.55, 0.55, 0.55)
-                .translation(0.01, 0.01, 0.01),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        right.material = material;
-        right
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.7, 0.7, 0.7)
+                    .rotation_y(-std::f64::consts::PI / 5.0)
+                    .translation(1.5, 0.7, 0.5),
+            )
+            .set_material({
+                let mut pattern = patterns::Pattern::checkers(color::black(), color::white());
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.55, 0.55, 0.55)
+                        .translation(0.01, 0.01, 0.01),
+                );
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Let there be light
     builder.add_light_source(lights::point_light(
@@ -374,61 +398,67 @@ fn test_ring_cylinder() -> Result<(), std::io::Error> {
     // Create a floor and add it to the scene. A plane rather than the
     // squashed sphere the other pattern scenes use: the camera sits high
     // enough here that the sphere's edge would show.
-    builder.add_shape({
-        let mut floor = shape::Shape::default_plane();
-        let mut material = material::material();
-        material.color = color::color(1.0, 0.9, 0.9);
-        material.specular = 0.0;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::plane()
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(1.0, 0.9, 0.9);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     // Add a cylinder to the left with the ring pattern rotated onto its
     // side, so the rings arc around the barrel
-    builder.add_shape({
-        let mut left = shape::Shape::cylinder(0.0, 1.5, true);
-        left.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.5, 1.0, 0.5)
-                .translation(-1.5, 0.0, 0.5),
-        );
-        let mut pattern = patterns::Pattern::ring(color::black(), color::white());
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.35, 0.35, 0.35)
-                .rotation_x(std::f64::consts::PI / 2.0),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        left.material = material;
-        left
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cylinder(0.0, 1.5, true)
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.5, 1.0, 0.5)
+                    .translation(-1.5, 0.0, 0.5),
+            )
+            .set_material({
+                let mut pattern = patterns::Pattern::ring(color::black(), color::white());
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.35, 0.35, 0.35)
+                        .rotation_x(std::f64::consts::PI / 2.0),
+                );
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Add a cylinder to the right with the rings around the cylinder's own
     // axis, showing a bullseye on the top cap. The barrel is a constant
     // distance from the axis so it lands in a single ring; the scale is
     // chosen so that ring is white and no ring boundary sits exactly on
     // the rim of the cap.
-    builder.add_shape({
-        let mut right = shape::Shape::cylinder(0.0, 1.5, true);
-        right.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.5, 1.0, 0.5)
-                .translation(1.5, 0.0, 0.5),
-        );
-        let mut pattern = patterns::Pattern::ring(color::black(), color::white());
-        pattern.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(0.3, 0.3, 0.3));
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        right.material = material;
-        right
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cylinder(0.0, 1.5, true)
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.5, 1.0, 0.5)
+                    .translation(1.5, 0.0, 0.5),
+            )
+            .set_material({
+                let mut pattern = patterns::Pattern::ring(color::black(), color::white());
+                pattern.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(0.3, 0.3, 0.3));
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Let there be light
     builder.add_light_source(lights::point_light(
@@ -473,65 +503,71 @@ fn test_stripe_cube() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // Create a floor and add it to the scene
-    builder.add_shape({
-        let mut floor = shape::Shape::default_sphere();
-        floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
-        let mut material = material::material();
-        material.color = color::color(1.0, 0.9, 0.9);
-        material.specular = 0.0;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0))
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(1.0, 0.9, 0.9);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     // Add a cube to the left with vertical stripes. The pattern is scaled
     // and nudged so stripe boundaries don't land exactly on the cube faces.
-    builder.add_shape({
-        let mut left = shape::Shape::default_cube();
-        left.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.7, 0.7, 0.7)
-                .rotation_y(std::f64::consts::PI / 6.0)
-                .translation(-1.5, 0.7, 0.5),
-        );
-        let mut pattern = patterns::Pattern::stripe(color::black(), color::white());
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.25, 0.25, 0.25)
-                .translation(0.01, 0.0, 0.0),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        left.material = material;
-        left
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.7, 0.7, 0.7)
+                    .rotation_y(std::f64::consts::PI / 6.0)
+                    .translation(-1.5, 0.7, 0.5),
+            )
+            .set_material({
+                let mut pattern = patterns::Pattern::stripe(color::black(), color::white());
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.25, 0.25, 0.25)
+                        .translation(0.01, 0.0, 0.0),
+                );
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Add a cube to the right with the stripes running horizontally
-    builder.add_shape({
-        let mut right = shape::Shape::default_cube();
-        right.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.7, 0.7, 0.7)
-                .rotation_y(-std::f64::consts::PI / 5.0)
-                .translation(1.5, 0.7, 0.5),
-        );
-        let mut pattern = patterns::Pattern::stripe(color::black(), color::white());
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.25, 0.25, 0.25)
-                .rotation_z(std::f64::consts::PI / 2.0)
-                .translation(0.0, 0.01, 0.0),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        right.material = material;
-        right
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::cube()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .scaling(0.7, 0.7, 0.7)
+                    .rotation_y(-std::f64::consts::PI / 5.0)
+                    .translation(1.5, 0.7, 0.5),
+            )
+            .set_material({
+                let mut pattern = patterns::Pattern::stripe(color::black(), color::white());
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.25, 0.25, 0.25)
+                        .rotation_z(std::f64::consts::PI / 2.0)
+                        .translation(0.0, 0.01, 0.0),
+                );
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Let there be light
     builder.add_light_source(lights::point_light(
@@ -573,60 +609,66 @@ fn test_stripe_sphere() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // Create a floor and add it to the scene
-    builder.add_shape({
-        let mut floor = shape::Shape::default_sphere();
-        floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
-        let mut material = material::material();
-        material.color = color::color(1.0, 0.9, 0.9);
-        material.specular = 0.0;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0))
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(1.0, 0.9, 0.9);
+                material.specular = 0.0;
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere to the left
-    builder.add_shape({
-        let mut left = shape::Shape::default_sphere();
-        left.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-1.5, 1.0, 0.5));
-        // Scaled down so several stripes fit on the sphere, and nudged so
-        // stripe boundaries don't land exactly on the sphere's poles.
-        let mut pattern = patterns::Pattern::stripe(color::black(), color::white());
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.25, 0.25, 0.25)
-                .rotation_x(3.0)
-                .translation(0.01, 0.0, 0.0),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        left.material = material;
-        left
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.translation(-1.5, 1.0, 0.5))
+            .set_material({
+                // Scaled down so several stripes fit on the sphere, and nudged so
+                // stripe boundaries don't land exactly on the sphere's poles.
+                let mut pattern = patterns::Pattern::stripe(color::black(), color::white());
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.25, 0.25, 0.25)
+                        .rotation_x(3.0)
+                        .translation(0.01, 0.0, 0.0),
+                );
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere to the right
-    builder.add_shape({
-        let mut right = shape::Shape::default_sphere();
-        right.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .rotation_z(-std::f64::consts::PI / 2.0)
-                .translation(1.5, 1.0, 0.5),
-        );
-        let mut pattern = patterns::Pattern::stripe(color::black(), color::white());
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.25, 0.25, 0.25)
-                .translation(0.01, 0.0, 0.0),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.1, 1.0, 0.5);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.pattern = Some(pattern);
-        right.material = material;
-        right
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .rotation_z(-std::f64::consts::PI / 2.0)
+                    .translation(1.5, 1.0, 0.5),
+            )
+            .set_material({
+                let mut pattern = patterns::Pattern::stripe(color::black(), color::white());
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.25, 0.25, 0.25)
+                        .translation(0.01, 0.0, 0.0),
+                );
+                let mut material = material::material();
+                material.color = color::color(0.1, 1.0, 0.5);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Let there be light
     builder.add_light_source(lights::point_light(

--- a/tests/render_reflection_and_refraction_test.rs
+++ b/tests/render_reflection_and_refraction_test.rs
@@ -14,64 +14,72 @@ fn test_reflective_scene() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // Create a floor and add it to the scene
-    builder.add_shape({
-        let mut floor = shape::Shape::default_plane();
-        floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
-        let mut material = material::material();
-        material.color = color::color(1.0, 1.0, 1.0);
-        material.specular = 0.0;
-        material.reflective = 0.5;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::plane()
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0))
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(1.0, 1.0, 1.0);
+                material.specular = 0.0;
+                material.reflective = 0.5;
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere to the left
-    builder.add_shape({
-        let mut left = shape::Shape::default_sphere();
-        left.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .translation(-2.5, 1.0, 0.5)
-                .scaling(0.7, 0.7, 0.7),
-        );
-        let mut material = material::material();
-        material.color = color::color(1.0, 0.0, 0.0);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        left.material = material;
-        left
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .translation(-2.5, 1.0, 0.5)
+                    .scaling(0.7, 0.7, 0.7),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(1.0, 0.0, 0.0);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere in the middle
-    builder.add_shape({
-        let mut middle = shape::Shape::default_sphere();
-        middle.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .translation(0.0, 1.0, 0.5)
-                .scaling(0.7, 0.7, 0.7),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.0, 1.0, 0.0);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        middle.material = material;
-        middle
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .translation(0.0, 1.0, 0.5)
+                    .scaling(0.7, 0.7, 0.7),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.0, 1.0, 0.0);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere to the right
-    builder.add_shape({
-        let mut right = shape::Shape::default_sphere();
-        right.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .translation(2.5, 1.0, 0.5)
-                .scaling(0.7, 0.7, 0.7),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.0, 0.0, 1.0);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        right.material = material;
-        right
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .translation(2.5, 1.0, 0.5)
+                    .scaling(0.7, 0.7, 0.7),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.0, 0.0, 1.0);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material
+            })
+            .build(),
+    );
     // Let there be light
     builder.add_light_source(lights::point_light(
         tuple::Point::new(-10.0, 10.0, -10.0),
@@ -104,67 +112,75 @@ fn test_very_reflective_scene() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // Create a floor and add it to the scene
-    builder.add_shape({
-        let mut floor = shape::Shape::default_plane();
-        floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
-        let mut material = material::material();
-        material.color = color::color(1.0, 1.0, 1.0);
-        material.specular = 0.0;
-        material.reflective = 0.5;
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::plane()
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0))
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(1.0, 1.0, 1.0);
+                material.specular = 0.0;
+                material.reflective = 0.5;
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere to the left
-    builder.add_shape({
-        let mut left = shape::Shape::default_sphere();
-        left.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .translation(-2.5, 1.0, 0.5)
-                .scaling(0.7, 0.7, 0.7),
-        );
-        let mut material = material::material();
-        material.color = color::color(1.0, 0.0, 0.0);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.reflective = 0.5;
-        left.material = material;
-        left
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .translation(-2.5, 1.0, 0.5)
+                    .scaling(0.7, 0.7, 0.7),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(1.0, 0.0, 0.0);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.reflective = 0.5;
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere in the middle
-    builder.add_shape({
-        let mut middle = shape::Shape::default_sphere();
-        middle.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .translation(0.0, 1.0, 0.5)
-                .scaling(0.7, 0.7, 0.7),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.0, 1.0, 0.0);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.reflective = 0.5;
-        middle.material = material;
-        middle
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .translation(0.0, 1.0, 0.5)
+                    .scaling(0.7, 0.7, 0.7),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.0, 1.0, 0.0);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.reflective = 0.5;
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere to the right
-    builder.add_shape({
-        let mut right = shape::Shape::default_sphere();
-        right.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .translation(2.5, 1.0, 0.5)
-                .scaling(0.7, 0.7, 0.7),
-        );
-        let mut material = material::material();
-        material.color = color::color(0.0, 0.0, 1.0);
-        material.diffuse = 0.7;
-        material.specular = 0.3;
-        material.reflective = 0.5;
-        right.material = material;
-        right
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::sphere()
+            .set_transform(
+                matrix::Matrix4::IDENTITY
+                    .translation(2.5, 1.0, 0.5)
+                    .scaling(0.7, 0.7, 0.7),
+            )
+            .set_material({
+                let mut material = material::material();
+                material.color = color::color(0.0, 0.0, 1.0);
+                material.diffuse = 0.7;
+                material.specular = 0.3;
+                material.reflective = 0.5;
+                material
+            })
+            .build(),
+    );
     // Let there be light
     builder.add_light_source(lights::point_light(
         tuple::Point::new(-5.0, 10.0, -10.0),
@@ -198,33 +214,37 @@ fn test_glass_sphere_scene() -> Result<(), std::io::Error> {
     let mut builder = world::WorldBuilder::new();
 
     // Create a floor and add it to the scene
-    builder.add_shape({
-        let mut floor = shape::Shape::default_plane();
-        floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(100.0, 0.01, 100.0));
-        let mut material = material::material();
-        let mut pattern =
-            patterns::Pattern::checkers(color::color(0.5, 0.5, 0.5), color::color(0.7, 0.7, 0.7));
-        // The y translation nudges the pattern off the y=0 checker boundary; intersection
-        // points on the plane straddle y=0 within float error, and which side they land on
-        // differs between platforms, which made this fixture fail on CI. The offset must
-        // not be a whole number of checker cells (cells are 0.005 here), or it lands back
-        // on a boundary: half a cell puts every point safely inside one.
-        pattern.set_transformation_matrix(
-            matrix::Matrix4::IDENTITY
-                .scaling(0.005, 0.005, 0.005)
-                .translation(0.0, 0.0025, 0.0),
-        );
-        material.pattern = Some(pattern);
-        floor.material = material;
-        floor
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::plane()
+            .set_transform(matrix::Matrix4::IDENTITY.scaling(100.0, 0.01, 100.0))
+            .set_material({
+                let mut material = material::material();
+                let mut pattern = patterns::Pattern::checkers(
+                    color::color(0.5, 0.5, 0.5),
+                    color::color(0.7, 0.7, 0.7),
+                );
+                // The y translation nudges the pattern off the y=0 checker boundary; intersection
+                // points on the plane straddle y=0 within float error, and which side they land on
+                // differs between platforms, which made this fixture fail on CI. The offset must
+                // not be a whole number of checker cells (cells are 0.005 here), or it lands back
+                // on a boundary: half a cell puts every point safely inside one.
+                pattern.set_transformation_matrix(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.005, 0.005, 0.005)
+                        .translation(0.0, 0.0025, 0.0),
+                );
+                material.pattern = Some(pattern);
+                material
+            })
+            .build(),
+    );
 
     // Add a sphere to the left
-    builder.add_shape({
-        let mut sphere = shape::Shape::glass_sphere();
-        sphere.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(0.0, 1.0, 0.0));
-        sphere
-    });
+    builder.add_shape(
+        shape::ShapeBuilder::glass_sphere()
+            .set_transform(matrix::Matrix4::IDENTITY.translation(0.0, 1.0, 0.0))
+            .build(),
+    );
 
     // Let there be light
     builder.add_light_source(lights::point_light(

--- a/tests/render_simple_world.rs
+++ b/tests/render_simple_world.rs
@@ -34,93 +34,105 @@ mod test_helpers {
         let mut builder = world::WorldBuilder::new();
 
         // Create a floor and add it to the scene
-        builder.add_shape({
-            let mut floor = shape::Shape::default_sphere();
-            floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
-            let mut material = material::material();
-            material.color = color::color(1.0, 0.9, 0.9);
-            material.specular = 0.0;
-            floor.material = material;
-            floor
-        });
+        builder.add_shape(
+            shape::ShapeBuilder::sphere()
+                .set_transform(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0))
+                .set_material({
+                    let mut material = material::material();
+                    material.color = color::color(1.0, 0.9, 0.9);
+                    material.specular = 0.0;
+                    material
+                })
+                .build(),
+        );
 
         // Create a wall and add it to the scene
-        builder.add_shape({
-            let mut left_wall = shape::Shape::default_sphere();
-            left_wall.set_transformation_matrix(
-                matrix::Matrix4::IDENTITY
-                    .scaling(10.0, 0.01, 10.0)
-                    .rotation_x(std::f64::consts::PI / 2.0)
-                    .rotation_y(-std::f64::consts::PI / 4.0)
-                    .translation(0.0, 0.0, 5.0),
-            );
-            let mut material = material::material();
-            material.color = color::color(1.0, 0.9, 0.9);
-            material.specular = 0.0;
-            left_wall.material = material;
-            left_wall
-        });
+        builder.add_shape(
+            shape::ShapeBuilder::sphere()
+                .set_transform(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(10.0, 0.01, 10.0)
+                        .rotation_x(std::f64::consts::PI / 2.0)
+                        .rotation_y(-std::f64::consts::PI / 4.0)
+                        .translation(0.0, 0.0, 5.0),
+                )
+                .set_material({
+                    let mut material = material::material();
+                    material.color = color::color(1.0, 0.9, 0.9);
+                    material.specular = 0.0;
+                    material
+                })
+                .build(),
+        );
 
         // Create another wall and add it to the scene
-        builder.add_shape({
-            let mut right_wall = shape::Shape::default_sphere();
-            right_wall.set_transformation_matrix(
-                matrix::Matrix4::IDENTITY
-                    .scaling(10.0, 0.01, 10.0)
-                    .rotation_x(std::f64::consts::PI / 2.0)
-                    .rotation_y(std::f64::consts::PI / 4.0)
-                    .translation(0.0, 0.0, 5.0),
-            );
-            let mut material = material::material();
-            material.color = color::color(1.0, 0.9, 0.9);
-            material.specular = 0.0;
-            right_wall.material = material;
-            right_wall
-        });
+        builder.add_shape(
+            shape::ShapeBuilder::sphere()
+                .set_transform(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(10.0, 0.01, 10.0)
+                        .rotation_x(std::f64::consts::PI / 2.0)
+                        .rotation_y(std::f64::consts::PI / 4.0)
+                        .translation(0.0, 0.0, 5.0),
+                )
+                .set_material({
+                    let mut material = material::material();
+                    material.color = color::color(1.0, 0.9, 0.9);
+                    material.specular = 0.0;
+                    material
+                })
+                .build(),
+        );
 
         // Add a sphere to the center
-        builder.add_shape({
-            let mut middle = shape::Shape::default_sphere();
-            middle.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-0.5, 1.0, 0.5));
-            let mut material = material::material();
-            material.color = color::color(0.1, 1.0, 0.5);
-            material.diffuse = 0.7;
-            material.specular = 0.3;
-            middle.material = material;
-            middle
-        });
+        builder.add_shape(
+            shape::ShapeBuilder::sphere()
+                .set_transform(matrix::Matrix4::IDENTITY.translation(-0.5, 1.0, 0.5))
+                .set_material({
+                    let mut material = material::material();
+                    material.color = color::color(0.1, 1.0, 0.5);
+                    material.diffuse = 0.7;
+                    material.specular = 0.3;
+                    material
+                })
+                .build(),
+        );
 
         // Add a small green sphere on the right
-        builder.add_shape({
-            let mut right = shape::Shape::default_sphere();
-            right.set_transformation_matrix(
-                matrix::Matrix4::IDENTITY
-                    .scaling(0.5, 0.5, 0.5)
-                    .translation(1.5, 0.5, 0.5),
-            );
-            let mut material = material::material();
-            material.color = color::color(0.1, 1.0, 0.5);
-            material.diffuse = 0.7;
-            material.specular = 0.3;
-            right.material = material;
-            right
-        });
+        builder.add_shape(
+            shape::ShapeBuilder::sphere()
+                .set_transform(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.5, 0.5, 0.5)
+                        .translation(1.5, 0.5, 0.5),
+                )
+                .set_material({
+                    let mut material = material::material();
+                    material.color = color::color(0.1, 1.0, 0.5);
+                    material.diffuse = 0.7;
+                    material.specular = 0.3;
+                    material
+                })
+                .build(),
+        );
 
         // Add a smaller green sphere on the left
-        builder.add_shape({
-            let mut left = shape::Shape::default_sphere();
-            left.set_transformation_matrix(
-                matrix::Matrix4::IDENTITY
-                    .scaling(0.3333, 0.3333, 0.3333)
-                    .translation(-1.5, 0.33, -0.75),
-            );
-            let mut material = material::material();
-            material.color = color::color(1.0, 0.8, 0.1);
-            material.diffuse = 0.7;
-            material.specular = 0.3;
-            left.material = material;
-            left
-        });
+        builder.add_shape(
+            shape::ShapeBuilder::sphere()
+                .set_transform(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.3333, 0.3333, 0.3333)
+                        .translation(-1.5, 0.33, -0.75),
+                )
+                .set_material({
+                    let mut material = material::material();
+                    material.color = color::color(1.0, 0.8, 0.1);
+                    material.diffuse = 0.7;
+                    material.specular = 0.3;
+                    material
+                })
+                .build(),
+        );
 
         // Let there be light
         builder.add_light_source(lights::point_light(
@@ -135,59 +147,67 @@ mod test_helpers {
         let mut builder = world::WorldBuilder::new();
 
         // Create a floor and add it to the scene
-        builder.add_shape({
-            let mut floor = shape::Shape::default_plane();
-            floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
-            let mut material = material::material();
-            material.color = color::color(1.0, 0.9, 0.9);
-            material.specular = 0.0;
-            floor.material = material;
-            floor
-        });
+        builder.add_shape(
+            shape::ShapeBuilder::plane()
+                .set_transform(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0))
+                .set_material({
+                    let mut material = material::material();
+                    material.color = color::color(1.0, 0.9, 0.9);
+                    material.specular = 0.0;
+                    material
+                })
+                .build(),
+        );
 
         // Add a sphere to the center
-        builder.add_shape({
-            let mut middle = shape::Shape::default_sphere();
-            middle.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-0.5, 1.0, 0.5));
-            let mut material = material::material();
-            material.color = color::color(0.1, 1.0, 0.5);
-            material.diffuse = 0.7;
-            material.specular = 0.3;
-            middle.material = material;
-            middle
-        });
+        builder.add_shape(
+            shape::ShapeBuilder::sphere()
+                .set_transform(matrix::Matrix4::IDENTITY.translation(-0.5, 1.0, 0.5))
+                .set_material({
+                    let mut material = material::material();
+                    material.color = color::color(0.1, 1.0, 0.5);
+                    material.diffuse = 0.7;
+                    material.specular = 0.3;
+                    material
+                })
+                .build(),
+        );
 
         // Add a small green sphere on the right
-        builder.add_shape({
-            let mut right = shape::Shape::default_sphere();
-            right.set_transformation_matrix(
-                matrix::Matrix4::IDENTITY
-                    .scaling(0.5, 0.5, 0.5)
-                    .translation(1.5, 0.5, 0.5),
-            );
-            let mut material = material::material();
-            material.color = color::color(0.1, 1.0, 0.5);
-            material.diffuse = 0.7;
-            material.specular = 0.3;
-            right.material = material;
-            right
-        });
+        builder.add_shape(
+            shape::ShapeBuilder::sphere()
+                .set_transform(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.5, 0.5, 0.5)
+                        .translation(1.5, 0.5, 0.5),
+                )
+                .set_material({
+                    let mut material = material::material();
+                    material.color = color::color(0.1, 1.0, 0.5);
+                    material.diffuse = 0.7;
+                    material.specular = 0.3;
+                    material
+                })
+                .build(),
+        );
 
         // Add a smaller green sphere on the left
-        builder.add_shape({
-            let mut left = shape::Shape::default_sphere();
-            left.set_transformation_matrix(
-                matrix::Matrix4::IDENTITY
-                    .scaling(0.3333, 0.3333, 0.3333)
-                    .translation(-1.5, 0.33, -0.75),
-            );
-            let mut material = material::material();
-            material.color = color::color(1.0, 0.8, 0.1);
-            material.diffuse = 0.7;
-            material.specular = 0.3;
-            left.material = material;
-            left
-        });
+        builder.add_shape(
+            shape::ShapeBuilder::sphere()
+                .set_transform(
+                    matrix::Matrix4::IDENTITY
+                        .scaling(0.3333, 0.3333, 0.3333)
+                        .translation(-1.5, 0.33, -0.75),
+                )
+                .set_material({
+                    let mut material = material::material();
+                    material.color = color::color(1.0, 0.8, 0.1);
+                    material.diffuse = 0.7;
+                    material.specular = 0.3;
+                    material
+                })
+                .build(),
+        );
 
         // Let there be light
         builder.add_light_source(lights::point_light(
@@ -202,40 +222,43 @@ mod test_helpers {
         let mut builder = world::WorldBuilder::new();
 
         // Create a floor and add it to the scene
-        builder.add_shape({
-            let mut floor = shape::Shape::default_plane();
-            floor.set_transformation_matrix(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0));
-
-            let mut material = material::material();
-            material.color = color::color(1.0, 0.9, 0.9);
-            if reflective_floor {
-                material.reflective = 0.8;
-            }
-            material.specular = 0.0;
-            let mut pattern = patterns::Pattern::checkers(color::black(), color::white());
-            // The y translation nudges the pattern off the y=0 checker boundary; intersection
-            // points on the plane straddle y=0 within float error, which speckles the checkers.
-            pattern.set_transformation_matrix(
-                matrix::Matrix4::IDENTITY
-                    .scaling(0.1, 0.1, 0.1)
-                    .translation(0.0, 0.01, 0.0),
-            );
-            material.pattern = Some(pattern);
-            floor.material = material;
-            floor
-        });
+        builder.add_shape(
+            shape::ShapeBuilder::plane()
+                .set_transform(matrix::Matrix4::IDENTITY.scaling(10.0, 0.01, 10.0))
+                .set_material({
+                    let mut material = material::material();
+                    material.color = color::color(1.0, 0.9, 0.9);
+                    if reflective_floor {
+                        material.reflective = 0.8;
+                    }
+                    material.specular = 0.0;
+                    let mut pattern = patterns::Pattern::checkers(color::black(), color::white());
+                    // The y translation nudges the pattern off the y=0 checker boundary; intersection
+                    // points on the plane straddle y=0 within float error, which speckles the checkers.
+                    pattern.set_transformation_matrix(
+                        matrix::Matrix4::IDENTITY
+                            .scaling(0.1, 0.1, 0.1)
+                            .translation(0.0, 0.01, 0.0),
+                    );
+                    material.pattern = Some(pattern);
+                    material
+                })
+                .build(),
+        );
 
         // Add a sphere to the center
-        builder.add_shape({
-            let mut middle = shape::Shape::default_sphere();
-            middle.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(-0.5, 1.0, 0.5));
-            let mut material = material::material();
-            material.color = color::color(0.1, 1.0, 0.5);
-            material.diffuse = 0.7;
-            material.specular = 0.3;
-            middle.material = material;
-            middle
-        });
+        builder.add_shape(
+            shape::ShapeBuilder::sphere()
+                .set_transform(matrix::Matrix4::IDENTITY.translation(-0.5, 1.0, 0.5))
+                .set_material({
+                    let mut material = material::material();
+                    material.color = color::color(0.1, 1.0, 0.5);
+                    material.diffuse = 0.7;
+                    material.specular = 0.3;
+                    material
+                })
+                .build(),
+        );
 
         // Let there be light
         builder.add_light_source(lights::point_light(


### PR DESCRIPTION
Shapes were built via default_<shape>() constructors plus a separate set_transformation_matrix call and direct material field mutation, needing a `let mut` binding and several statements to configure one shape. That boilerplate was especially visible across the render test scenes in `tests/`, which build up dozens of shapes per file.

Added `shape::ShapeBuilder`, mirroring `WorldBuilder`: a constructor per shape type, chainable `set_transform`/`set_material`/`add_child` methods, and `build()` to unwrap the finished `Shape`. A `From<Shape>` impl lets it resume building an already-constructed shape, e.g. to transform a group returned by a helper function or an imported OBJ model.

Migrated every `tests/render_*.rs` scene that builds a world via `WorldBuilder` to construct its shapes with `ShapeBuilder`, matching how `WorldBuilder` itself is scoped: unit tests inline in `src/*.rs` are untouched. Also updated the README's "Possible improvements" list, removing the two items this resolves.