### PR TITLE
Add bounding boxes from the bonus chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,5 +583,6 @@ a change that you expect to improve performance and know if it worked on not.
 
 ## Possible improvements
 
-- Bounding boxes to speed up intersection tests against groups and
-  imported OBJ models.
+- Bounding volume hierarchies: recursively subdividing large groups
+  (like imported OBJ models) into nested subgroups, so a ray descends
+  only into the halves of the model its path actually crosses.

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,0 +1,334 @@
+use crate::matrix;
+use crate::ray;
+use crate::tuple;
+
+// An axis-aligned bounding box: the smallest box, with faces parallel to
+// the axes, that encloses a shape. Rays that miss the box cannot hit
+// anything inside it, so an inexpensive box test can skip whole subtrees
+// of expensive shape tests.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BoundingBox {
+    pub min: tuple::Point,
+    pub max: tuple::Point,
+}
+
+impl BoundingBox {
+    // An empty box has its extents inverted, so that the first point added
+    // establishes both of them and any containment check fails.
+    pub fn empty() -> BoundingBox {
+        BoundingBox {
+            min: tuple::Point::new(f64::INFINITY, f64::INFINITY, f64::INFINITY),
+            max: tuple::Point::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY),
+        }
+    }
+
+    pub fn new(min: tuple::Point, max: tuple::Point) -> BoundingBox {
+        BoundingBox { min, max }
+    }
+
+    pub fn add_point(&mut self, point: tuple::Point) {
+        self.min.x = self.min.x.min(point.x);
+        self.min.y = self.min.y.min(point.y);
+        self.min.z = self.min.z.min(point.z);
+        self.max.x = self.max.x.max(point.x);
+        self.max.y = self.max.y.max(point.y);
+        self.max.z = self.max.z.max(point.z);
+    }
+
+    pub fn add_box(&mut self, other: &BoundingBox) {
+        self.add_point(other.min);
+        self.add_point(other.max);
+    }
+
+    pub fn contains_point(&self, point: tuple::Point) -> bool {
+        (self.min.x..=self.max.x).contains(&point.x)
+            && (self.min.y..=self.max.y).contains(&point.y)
+            && (self.min.z..=self.max.z).contains(&point.z)
+    }
+
+    pub fn contains_box(&self, other: &BoundingBox) -> bool {
+        self.contains_point(other.min) && self.contains_point(other.max)
+    }
+
+    // The box that encloses this box after a transformation. Transforming
+    // only the two extents would be wrong for rotations, so all eight
+    // corners are transformed and a new box grown around them.
+    pub fn transform(&self, transform: &matrix::Matrix4) -> BoundingBox {
+        let corners = [
+            tuple::Point::new(self.min.x, self.min.y, self.min.z),
+            tuple::Point::new(self.min.x, self.min.y, self.max.z),
+            tuple::Point::new(self.min.x, self.max.y, self.min.z),
+            tuple::Point::new(self.min.x, self.max.y, self.max.z),
+            tuple::Point::new(self.max.x, self.min.y, self.min.z),
+            tuple::Point::new(self.max.x, self.min.y, self.max.z),
+            tuple::Point::new(self.max.x, self.max.y, self.min.z),
+            tuple::Point::new(self.max.x, self.max.y, self.max.z),
+        ];
+
+        let mut result = BoundingBox::empty();
+        for corner in corners {
+            result.add_point(*transform * corner);
+        }
+        return result;
+    }
+
+    // Whether the ray strikes the box. This is the cube intersection
+    // generalized to arbitrary extents, except only the yes/no answer is
+    // needed, not the `t` values.
+    pub fn intersects(&self, ray: &ray::Ray) -> bool {
+        let (xtmin, xtmax) = check_axis(ray.origin.x, ray.direction.x, self.min.x, self.max.x);
+        let (ytmin, ytmax) = check_axis(ray.origin.y, ray.direction.y, self.min.y, self.max.y);
+        let (ztmin, ztmax) = check_axis(ray.origin.z, ray.direction.z, self.min.z, self.max.z);
+
+        let tmin = xtmin.max(ytmin).max(ztmin);
+        let tmax = xtmax.min(ytmax).min(ztmax);
+
+        return tmin <= tmax;
+    }
+}
+
+fn check_axis(origin: f64, direction: f64, min: f64, max: f64) -> (f64, f64) {
+    let tmin = (min - origin) / direction;
+    let tmax = (max - origin) / direction;
+
+    if tmin > tmax {
+        return (tmax, tmin);
+    }
+    return (tmin, tmax);
+}
+
+#[cfg(test)]
+mod bounds_tests {
+    use crate::bounds;
+    use crate::matrix;
+    use crate::ray;
+    use crate::transformation::Transform;
+    use crate::tuple;
+
+    #[test]
+    fn test_creating_an_empty_bounding_box() {
+        let bbox = bounds::BoundingBox::empty();
+
+        assert_eq!(
+            bbox.min,
+            tuple::Point::new(f64::INFINITY, f64::INFINITY, f64::INFINITY)
+        );
+        assert_eq!(
+            bbox.max,
+            tuple::Point::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY)
+        );
+    }
+
+    #[test]
+    fn test_creating_a_bounding_box_with_volume() {
+        let bbox = bounds::BoundingBox::new(
+            tuple::Point::new(-1.0, -2.0, -3.0),
+            tuple::Point::new(3.0, 2.0, 1.0),
+        );
+
+        assert_eq!(bbox.min, tuple::Point::new(-1.0, -2.0, -3.0));
+        assert_eq!(bbox.max, tuple::Point::new(3.0, 2.0, 1.0));
+    }
+
+    #[test]
+    fn test_adding_points_to_an_empty_bounding_box() {
+        let mut bbox = bounds::BoundingBox::empty();
+
+        bbox.add_point(tuple::Point::new(-5.0, 2.0, 0.0));
+        bbox.add_point(tuple::Point::new(7.0, 0.0, -3.0));
+
+        assert_eq!(bbox.min, tuple::Point::new(-5.0, 0.0, -3.0));
+        assert_eq!(bbox.max, tuple::Point::new(7.0, 2.0, 0.0));
+    }
+
+    #[test]
+    fn test_adding_one_bounding_box_to_another() {
+        let mut box1 = bounds::BoundingBox::new(
+            tuple::Point::new(-5.0, -2.0, 0.0),
+            tuple::Point::new(7.0, 4.0, 4.0),
+        );
+        let box2 = bounds::BoundingBox::new(
+            tuple::Point::new(8.0, -7.0, -2.0),
+            tuple::Point::new(14.0, 2.0, 8.0),
+        );
+
+        box1.add_box(&box2);
+
+        assert_eq!(box1.min, tuple::Point::new(-5.0, -7.0, -2.0));
+        assert_eq!(box1.max, tuple::Point::new(14.0, 4.0, 8.0));
+    }
+
+    #[test]
+    fn test_checking_to_see_if_a_box_contains_a_given_point() {
+        let bbox = bounds::BoundingBox::new(
+            tuple::Point::new(5.0, -2.0, 0.0),
+            tuple::Point::new(11.0, 4.0, 7.0),
+        );
+
+        let examples = [
+            (tuple::Point::new(5.0, -2.0, 0.0), true),
+            (tuple::Point::new(11.0, 4.0, 7.0), true),
+            (tuple::Point::new(8.0, 1.0, 3.0), true),
+            (tuple::Point::new(3.0, 0.0, 3.0), false),
+            (tuple::Point::new(8.0, -4.0, 3.0), false),
+            (tuple::Point::new(8.0, 1.0, -1.0), false),
+            (tuple::Point::new(13.0, 1.0, 3.0), false),
+            (tuple::Point::new(8.0, 5.0, 3.0), false),
+            (tuple::Point::new(8.0, 1.0, 8.0), false),
+        ];
+        for (point, expected) in examples {
+            assert_eq!(bbox.contains_point(point), expected);
+        }
+    }
+
+    #[test]
+    fn test_checking_to_see_if_a_box_contains_a_given_box() {
+        let bbox = bounds::BoundingBox::new(
+            tuple::Point::new(5.0, -2.0, 0.0),
+            tuple::Point::new(11.0, 4.0, 7.0),
+        );
+
+        let examples = [
+            (
+                tuple::Point::new(5.0, -2.0, 0.0),
+                tuple::Point::new(11.0, 4.0, 7.0),
+                true,
+            ),
+            (
+                tuple::Point::new(6.0, -1.0, 1.0),
+                tuple::Point::new(10.0, 3.0, 6.0),
+                true,
+            ),
+            (
+                tuple::Point::new(4.0, -3.0, -1.0),
+                tuple::Point::new(10.0, 3.0, 6.0),
+                false,
+            ),
+            (
+                tuple::Point::new(6.0, -1.0, 1.0),
+                tuple::Point::new(12.0, 5.0, 8.0),
+                false,
+            ),
+        ];
+        for (min, max, expected) in examples {
+            let other = bounds::BoundingBox::new(min, max);
+            assert_eq!(bbox.contains_box(&other), expected);
+        }
+    }
+
+    #[test]
+    fn test_transforming_a_bounding_box() {
+        let bbox = bounds::BoundingBox::new(
+            tuple::Point::new(-1.0, -1.0, -1.0),
+            tuple::Point::new(1.0, 1.0, 1.0),
+        );
+        let transform = matrix::Matrix4::IDENTITY
+            .rotation_y(std::f64::consts::PI / 4.0)
+            .rotation_x(std::f64::consts::PI / 4.0);
+
+        let transformed = bbox.transform(&transform);
+
+        crate::assert_tuple_approx_eq!(
+            transformed.min,
+            tuple::Point::new(-1.41421, -1.70711, -1.70711)
+        );
+        crate::assert_tuple_approx_eq!(
+            transformed.max,
+            tuple::Point::new(1.41421, 1.70711, 1.70711)
+        );
+    }
+
+    #[test]
+    fn test_intersecting_a_ray_with_a_bounding_box_at_the_origin() {
+        let bbox = bounds::BoundingBox::new(
+            tuple::Point::new(-1.0, -1.0, -1.0),
+            tuple::Point::new(1.0, 1.0, 1.0),
+        );
+
+        let examples = [
+            ((5.0, 0.5, 0.0), (-1.0, 0.0, 0.0), true),
+            ((-5.0, 0.5, 0.0), (1.0, 0.0, 0.0), true),
+            ((0.5, 5.0, 0.0), (0.0, -1.0, 0.0), true),
+            ((0.5, -5.0, 0.0), (0.0, 1.0, 0.0), true),
+            ((0.5, 0.0, 5.0), (0.0, 0.0, -1.0), true),
+            ((0.5, 0.0, -5.0), (0.0, 0.0, 1.0), true),
+            ((0.0, 0.5, 0.0), (0.0, 0.0, 1.0), true),
+            ((-2.0, 0.0, 0.0), (2.0, 4.0, 6.0), false),
+            ((0.0, -2.0, 0.0), (6.0, 2.0, 4.0), false),
+            ((0.0, 0.0, -2.0), (4.0, 6.0, 2.0), false),
+            ((2.0, 0.0, 2.0), (0.0, 0.0, -1.0), false),
+            ((0.0, 2.0, 2.0), (0.0, -1.0, 0.0), false),
+            ((2.0, 2.0, 0.0), (-1.0, 0.0, 0.0), false),
+        ];
+        for ((ox, oy, oz), (dx, dy, dz), expected) in examples {
+            let direction = tuple::normalize(&tuple::Vector::new(dx, dy, dz));
+            let ray = ray::ray(tuple::Point::new(ox, oy, oz), direction);
+            assert_eq!(bbox.intersects(&ray), expected);
+        }
+    }
+
+    #[test]
+    fn test_intersecting_a_ray_with_a_non_cubic_bounding_box() {
+        let bbox = bounds::BoundingBox::new(
+            tuple::Point::new(5.0, -2.0, 0.0),
+            tuple::Point::new(11.0, 4.0, 7.0),
+        );
+
+        let examples = [
+            ((15.0, 1.0, 2.0), (-1.0, 0.0, 0.0), true),
+            ((-5.0, -1.0, 4.0), (1.0, 0.0, 0.0), true),
+            ((7.0, 6.0, 5.0), (0.0, -1.0, 0.0), true),
+            ((9.0, -5.0, 6.0), (0.0, 1.0, 0.0), true),
+            ((8.0, 2.0, 12.0), (0.0, 0.0, -1.0), true),
+            ((6.0, 0.0, -5.0), (0.0, 0.0, 1.0), true),
+            ((8.0, 1.0, 3.5), (0.0, 0.0, 1.0), true),
+            ((9.0, -1.0, -8.0), (2.0, 4.0, 6.0), false),
+            ((8.0, 3.0, -4.0), (6.0, 2.0, 4.0), false),
+            ((9.0, -1.0, -2.0), (4.0, 6.0, 2.0), false),
+            ((4.0, 0.0, 9.0), (0.0, 0.0, -1.0), false),
+            ((8.0, 6.0, -1.0), (0.0, -1.0, 0.0), false),
+            ((12.0, 5.0, 4.0), (-1.0, 0.0, 0.0), false),
+        ];
+        for ((ox, oy, oz), (dx, dy, dz), expected) in examples {
+            let direction = tuple::normalize(&tuple::Vector::new(dx, dy, dz));
+            let ray = ray::ray(tuple::Point::new(ox, oy, oz), direction);
+            assert_eq!(bbox.intersects(&ray), expected);
+        }
+    }
+
+    // Not from the book: an untransformed group is empty, and its inverted
+    // extents must reject every ray rather than yielding NaN comparisons
+    // that accept them.
+    #[test]
+    fn test_an_empty_box_intersects_nothing() {
+        let bbox = bounds::BoundingBox::empty();
+
+        let ray = ray::ray(
+            tuple::Point::new(0.0, 0.0, -5.0),
+            tuple::Vector::new(0.0, 0.0, 1.0),
+        );
+        assert!(!bbox.intersects(&ray));
+    }
+
+    #[test]
+    fn test_transforming_an_empty_box_leaves_it_empty() {
+        let bbox = bounds::BoundingBox::empty();
+
+        let transformed = bbox.transform(&matrix::Matrix4::IDENTITY.translation(1.0, 2.0, 3.0));
+
+        assert!(!transformed.contains_point(tuple::Point::new(1.0, 2.0, 3.0)));
+    }
+
+    fn transformed_is_empty(bbox: &bounds::BoundingBox) -> bool {
+        bbox.min.x > bbox.max.x
+    }
+
+    #[test]
+    fn test_transforming_an_empty_box_keeps_extents_inverted() {
+        let bbox = bounds::BoundingBox::empty();
+
+        let transformed = bbox.transform(&matrix::Matrix4::IDENTITY.translation(1.0, 2.0, 3.0));
+
+        assert!(transformed_is_empty(&transformed));
+    }
+}

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -72,10 +72,22 @@ impl BoundingBox {
         return result;
     }
 
+    // Whether the box encloses no space at all: extents stay inverted
+    // until a first point is added.
+    pub fn is_empty(&self) -> bool {
+        self.min.x > self.max.x || self.min.y > self.max.y || self.min.z > self.max.z
+    }
+
     // Whether the ray strikes the box. This is the cube intersection
     // generalized to arbitrary extents, except only the yes/no answer is
     // needed, not the `t` values.
     pub fn intersects(&self, ray: &ray::Ray) -> bool {
+        // An empty box's inverted extents would be swapped by `check_axis`
+        // into an infinite box that accepts every ray.
+        if self.is_empty() {
+            return false;
+        }
+
         let (xtmin, xtmax) = check_axis(ray.origin.x, ray.direction.x, self.min.x, self.max.x);
         let (ytmin, ytmax) = check_axis(ray.origin.y, ray.direction.y, self.min.y, self.max.y);
         let (ztmin, ztmax) = check_axis(ray.origin.z, ray.direction.z, self.min.z, self.max.z);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::style)]
 
+pub mod bounds;
 pub mod camera;
 pub mod canvas;
 pub mod color;

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -25,6 +25,10 @@ enum ShapeType {
     },
     Group {
         children: Vec<Shape>,
+        // The box enclosing every child, grown as children are added.
+        // Recomputing it by walking the children on every intersection
+        // would cost more than the per-child tests it is meant to avoid.
+        bounds: bounds::BoundingBox,
     },
     Triangle {
         p1: tuple::Point,
@@ -48,6 +52,9 @@ enum ShapeType {
         operation: CsgOperation,
         left: Box<Shape>,
         right: Box<Shape>,
+        // The box enclosing both children, fixed at construction since a
+        // CSG shape's children never change afterwards.
+        bounds: bounds::BoundingBox,
     },
     // A stand-in shape for tests: it records that an intersection was
     // attempted, so tests can observe whether an aggregate shape's bounding
@@ -165,18 +172,27 @@ impl Shape {
             material: material::material(),
             shape_type: ShapeType::Group {
                 children: Vec::new(),
+                bounds: bounds::BoundingBox::empty(),
             },
         };
     }
 
     pub fn add_child(&mut self, child: Shape) {
+        let child_bounds = child.parent_space_bounds();
         match &mut self.shape_type {
-            ShapeType::Group { children } => children.push(child),
+            ShapeType::Group { children, bounds } => {
+                bounds.add_box(&child_bounds);
+                children.push(child);
+            }
             _ => panic!("only groups can contain children"),
         }
     }
 
     pub fn csg(operation: CsgOperation, left: Shape, right: Shape) -> Shape {
+        let mut bounds = bounds::BoundingBox::empty();
+        bounds.add_box(&left.parent_space_bounds());
+        bounds.add_box(&right.parent_space_bounds());
+
         return Shape {
             transform: matrix::Matrix4::IDENTITY,
             material: material::material(),
@@ -184,6 +200,7 @@ impl Shape {
                 operation,
                 left: Box::new(left),
                 right: Box::new(right),
+                bounds,
             },
         };
     }
@@ -258,13 +275,55 @@ impl Shape {
     // The shape's axis-aligned bounding box, in object space (before the
     // shape's own transform is applied).
     pub fn bounds(&self) -> bounds::BoundingBox {
-        todo!("bounding boxes are not implemented yet")
+        match &self.shape_type {
+            ShapeType::Sphere | ShapeType::Cube => bounds::BoundingBox::new(
+                tuple::Point::new(-1.0, -1.0, -1.0),
+                tuple::Point::new(1.0, 1.0, 1.0),
+            ),
+            // A plane is infinite in x and z but has no thickness in y.
+            ShapeType::Plane => bounds::BoundingBox::new(
+                tuple::Point::new(f64::NEG_INFINITY, 0.0, f64::NEG_INFINITY),
+                tuple::Point::new(f64::INFINITY, 0.0, f64::INFINITY),
+            ),
+            ShapeType::Cylinder {
+                minimum, maximum, ..
+            } => bounds::BoundingBox::new(
+                tuple::Point::new(-1.0, *minimum, -1.0),
+                tuple::Point::new(1.0, *maximum, 1.0),
+            ),
+            // A cone's walls slope at 45 degrees, so its radius at either
+            // extent equals that extent's distance from the apex.
+            ShapeType::Cone {
+                minimum, maximum, ..
+            } => {
+                let limit = minimum.abs().max(maximum.abs());
+                bounds::BoundingBox::new(
+                    tuple::Point::new(-limit, *minimum, -limit),
+                    tuple::Point::new(limit, *maximum, limit),
+                )
+            }
+            ShapeType::Triangle { p1, p2, p3, .. }
+            | ShapeType::SmoothTriangle { p1, p2, p3, .. } => {
+                let mut bbox = bounds::BoundingBox::empty();
+                bbox.add_point(*p1);
+                bbox.add_point(*p2);
+                bbox.add_point(*p3);
+                bbox
+            }
+            ShapeType::Group { bounds, .. } => *bounds,
+            ShapeType::Csg { bounds, .. } => *bounds,
+            #[cfg(test)]
+            ShapeType::Test { .. } => bounds::BoundingBox::new(
+                tuple::Point::new(-1.0, -1.0, -1.0),
+                tuple::Point::new(1.0, 1.0, 1.0),
+            ),
+        }
     }
 
     // The shape's bounding box in the space of its parent: the object-space
     // box carried through this shape's own transform.
     pub fn parent_space_bounds(&self) -> bounds::BoundingBox {
-        todo!("bounding boxes are not implemented yet")
+        return self.bounds().transform(&self.transform);
     }
 
     fn sphere_local_normal_at(&self, object_point: tuple::Point) -> tuple::Vector {
@@ -407,7 +466,10 @@ impl Shape {
                 maximum,
                 closed,
             } => self.cone_local_intersect(local_ray, minimum, maximum, closed),
-            ShapeType::Group { ref children } => self.group_local_intersect(children, local_ray),
+            ShapeType::Group {
+                ref children,
+                ref bounds,
+            } => self.group_local_intersect(children, bounds, local_ray),
             ShapeType::Triangle { p1, e1, e2, .. } => {
                 self.triangle_local_intersect(local_ray, p1, e1, e2)
             }
@@ -417,8 +479,9 @@ impl Shape {
             ShapeType::Csg {
                 ref left,
                 ref right,
+                ref bounds,
                 ..
-            } => self.csg_local_intersect(left, right, local_ray),
+            } => self.csg_local_intersect(left, right, bounds, local_ray),
             #[cfg(test)]
             ShapeType::Test {
                 ref intersect_called,
@@ -470,8 +533,15 @@ impl Shape {
     fn group_local_intersect<'a>(
         &'a self,
         children: &'a [Shape],
+        bounds: &bounds::BoundingBox,
         local_ray: ray::Ray,
     ) -> Vec<intersection::Intersection<'a>> {
+        // A ray that misses the box enclosing every child cannot hit any
+        // of them, so all the per-child tests can be skipped.
+        if !bounds.intersects(&local_ray) {
+            return vec![];
+        }
+
         let mut intersections: Vec<intersection::Intersection<'a>> = children
             .iter()
             .flat_map(|child| child.intersect(&local_ray))
@@ -492,8 +562,15 @@ impl Shape {
         &'a self,
         left: &'a Shape,
         right: &'a Shape,
+        bounds: &bounds::BoundingBox,
         local_ray: ray::Ray,
     ) -> Vec<intersection::Intersection<'a>> {
+        // As with groups, a ray that misses the box enclosing both
+        // children cannot hit either of them.
+        if !bounds.intersects(&local_ray) {
+            return vec![];
+        }
+
         let mut intersections = left.intersect(&local_ray);
         intersections.extend(right.intersect(&local_ray));
 
@@ -548,7 +625,7 @@ impl Shape {
     // shapes on both sides of a CSG operation.
     fn includes(&self, other: &Shape) -> bool {
         match &self.shape_type {
-            ShapeType::Group { children } => children.iter().any(|child| child.includes(other)),
+            ShapeType::Group { children, .. } => children.iter().any(|child| child.includes(other)),
             ShapeType::Csg { left, right, .. } => left.includes(other) || right.includes(other),
             _ => std::ptr::eq(self, other),
         }
@@ -910,7 +987,7 @@ mod shape_builder_tests {
         let built = shape::ShapeBuilder::group().add_child(child).build();
 
         match &built.shape_type {
-            shape::ShapeType::Group { children } => assert_eq!(children.len(), 1),
+            shape::ShapeType::Group { children, .. } => assert_eq!(children.len(), 1),
             _ => panic!("expected a group shape"),
         }
     }
@@ -1618,7 +1695,7 @@ mod group_tests {
 
     fn children(group: &shape::Shape) -> &Vec<shape::Shape> {
         match &group.shape_type {
-            shape::ShapeType::Group { children } => children,
+            shape::ShapeType::Group { children, .. } => children,
             _ => panic!("expected a group"),
         }
     }
@@ -2005,6 +2082,7 @@ mod csg_tests {
                 operation,
                 left,
                 right,
+                ..
             } => (operation, left.as_ref(), right.as_ref()),
             _ => panic!("expected a csg shape"),
         }
@@ -2377,7 +2455,7 @@ mod bounding_box_tests {
 
     fn children(group: &shape::Shape) -> &Vec<shape::Shape> {
         match &group.shape_type {
-            shape::ShapeType::Group { children } => children,
+            shape::ShapeType::Group { children, .. } => children,
             _ => panic!("expected a group"),
         }
     }

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -1,3 +1,4 @@
+use crate::bounds;
 use crate::intersection;
 use crate::material;
 use crate::matrix;
@@ -47,6 +48,13 @@ enum ShapeType {
         operation: CsgOperation,
         left: Box<Shape>,
         right: Box<Shape>,
+    },
+    // A stand-in shape for tests: it records that an intersection was
+    // attempted, so tests can observe whether an aggregate shape's bounding
+    // box check skipped its children.
+    #[cfg(test)]
+    Test {
+        intersect_called: std::cell::Cell<bool>,
     },
 }
 
@@ -136,6 +144,17 @@ impl Shape {
                 minimum,
                 maximum,
                 closed,
+            },
+        };
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_shape() -> Shape {
+        return Shape {
+            transform: matrix::Matrix4::IDENTITY,
+            material: material::material(),
+            shape_type: ShapeType::Test {
+                intersect_called: std::cell::Cell::new(false),
             },
         };
     }
@@ -236,6 +255,18 @@ impl Shape {
         return self.local_intersect(local_ray);
     }
 
+    // The shape's axis-aligned bounding box, in object space (before the
+    // shape's own transform is applied).
+    pub fn bounds(&self) -> bounds::BoundingBox {
+        todo!("bounding boxes are not implemented yet")
+    }
+
+    // The shape's bounding box in the space of its parent: the object-space
+    // box carried through this shape's own transform.
+    pub fn parent_space_bounds(&self) -> bounds::BoundingBox {
+        todo!("bounding boxes are not implemented yet")
+    }
+
     fn sphere_local_normal_at(&self, object_point: tuple::Point) -> tuple::Vector {
         object_point - tuple::Point::new(0.0, 0.0, 0.0)
     }
@@ -329,6 +360,10 @@ impl Shape {
             // filtered intersections reference the primitive child that was
             // hit, so the child computes the normal.
             ShapeType::Csg { .. } => panic!("csg shapes do not have a local normal"),
+            #[cfg(test)]
+            ShapeType::Test { .. } => {
+                tuple::Vector::new(object_point.x, object_point.y, object_point.z)
+            }
         }
     }
 
@@ -384,6 +419,13 @@ impl Shape {
                 ref right,
                 ..
             } => self.csg_local_intersect(left, right, local_ray),
+            #[cfg(test)]
+            ShapeType::Test {
+                ref intersect_called,
+            } => {
+                intersect_called.set(true);
+                vec![]
+            }
         }
     }
 
@@ -2137,5 +2179,279 @@ mod csg_tests {
         assert_eq!(intersections[0].object, left);
         assert_eq!(intersections[1].t, 6.5);
         assert_eq!(intersections[1].object, right);
+    }
+}
+
+#[cfg(test)]
+mod bounding_box_tests {
+    use crate::matrix;
+    use crate::ray;
+    use crate::shape;
+    use crate::transformation::Transform;
+    use crate::tuple;
+
+    #[test]
+    fn test_a_sphere_has_a_bounding_box() {
+        let shape = shape::Shape::default_sphere();
+
+        let bbox = shape.bounds();
+
+        assert_eq!(bbox.min, tuple::Point::new(-1.0, -1.0, -1.0));
+        assert_eq!(bbox.max, tuple::Point::new(1.0, 1.0, 1.0));
+    }
+
+    #[test]
+    fn test_a_plane_has_a_bounding_box() {
+        let shape = shape::Shape::default_plane();
+
+        let bbox = shape.bounds();
+
+        assert_eq!(
+            bbox.min,
+            tuple::Point::new(f64::NEG_INFINITY, 0.0, f64::NEG_INFINITY)
+        );
+        assert_eq!(
+            bbox.max,
+            tuple::Point::new(f64::INFINITY, 0.0, f64::INFINITY)
+        );
+    }
+
+    #[test]
+    fn test_a_cube_has_a_bounding_box() {
+        let shape = shape::Shape::default_cube();
+
+        let bbox = shape.bounds();
+
+        assert_eq!(bbox.min, tuple::Point::new(-1.0, -1.0, -1.0));
+        assert_eq!(bbox.max, tuple::Point::new(1.0, 1.0, 1.0));
+    }
+
+    #[test]
+    fn test_an_unbounded_cylinder_has_a_bounding_box() {
+        let shape = shape::Shape::default_cylinder();
+
+        let bbox = shape.bounds();
+
+        assert_eq!(bbox.min, tuple::Point::new(-1.0, f64::NEG_INFINITY, -1.0));
+        assert_eq!(bbox.max, tuple::Point::new(1.0, f64::INFINITY, 1.0));
+    }
+
+    #[test]
+    fn test_a_bounded_cylinder_has_a_bounding_box() {
+        let shape = shape::Shape::cylinder(-5.0, 3.0, false);
+
+        let bbox = shape.bounds();
+
+        assert_eq!(bbox.min, tuple::Point::new(-1.0, -5.0, -1.0));
+        assert_eq!(bbox.max, tuple::Point::new(1.0, 3.0, 1.0));
+    }
+
+    #[test]
+    fn test_an_unbounded_cone_has_a_bounding_box() {
+        let shape = shape::Shape::default_cone();
+
+        let bbox = shape.bounds();
+
+        assert_eq!(
+            bbox.min,
+            tuple::Point::new(f64::NEG_INFINITY, f64::NEG_INFINITY, f64::NEG_INFINITY)
+        );
+        assert_eq!(
+            bbox.max,
+            tuple::Point::new(f64::INFINITY, f64::INFINITY, f64::INFINITY)
+        );
+    }
+
+    #[test]
+    fn test_a_bounded_cone_has_a_bounding_box() {
+        let shape = shape::Shape::cone(-5.0, 3.0, false);
+
+        let bbox = shape.bounds();
+
+        assert_eq!(bbox.min, tuple::Point::new(-5.0, -5.0, -5.0));
+        assert_eq!(bbox.max, tuple::Point::new(5.0, 3.0, 5.0));
+    }
+
+    #[test]
+    fn test_a_triangle_has_a_bounding_box() {
+        let shape = shape::Shape::triangle(
+            tuple::Point::new(-3.0, 7.0, 2.0),
+            tuple::Point::new(6.0, 2.0, -4.0),
+            tuple::Point::new(2.0, -1.0, -1.0),
+        );
+
+        let bbox = shape.bounds();
+
+        assert_eq!(bbox.min, tuple::Point::new(-3.0, -1.0, -4.0));
+        assert_eq!(bbox.max, tuple::Point::new(6.0, 7.0, 2.0));
+    }
+
+    // Not from the book: this implementation has smooth triangles as a
+    // distinct shape type, and their extent comes from the same three
+    // corners.
+    #[test]
+    fn test_a_smooth_triangle_has_a_bounding_box() {
+        let shape = shape::Shape::smooth_triangle(
+            tuple::Point::new(-3.0, 7.0, 2.0),
+            tuple::Point::new(6.0, 2.0, -4.0),
+            tuple::Point::new(2.0, -1.0, -1.0),
+            tuple::Vector::new(0.0, 1.0, 0.0),
+            tuple::Vector::new(0.0, 1.0, 0.0),
+            tuple::Vector::new(0.0, 1.0, 0.0),
+        );
+
+        let bbox = shape.bounds();
+
+        assert_eq!(bbox.min, tuple::Point::new(-3.0, -1.0, -4.0));
+        assert_eq!(bbox.max, tuple::Point::new(6.0, 7.0, 2.0));
+    }
+
+    #[test]
+    fn test_a_test_shape_has_arbitrary_bounds() {
+        let shape = shape::Shape::test_shape();
+
+        let bbox = shape.bounds();
+
+        assert_eq!(bbox.min, tuple::Point::new(-1.0, -1.0, -1.0));
+        assert_eq!(bbox.max, tuple::Point::new(1.0, 1.0, 1.0));
+    }
+
+    #[test]
+    fn test_querying_a_shapes_bounding_box_in_its_parents_space() {
+        let mut shape = shape::Shape::default_sphere();
+        shape.set_transformation_matrix(
+            matrix::Matrix4::IDENTITY
+                .scaling(0.5, 2.0, 4.0)
+                .translation(1.0, -3.0, 5.0),
+        );
+
+        let bbox = shape.parent_space_bounds();
+
+        assert_eq!(bbox.min, tuple::Point::new(0.5, -5.0, 1.0));
+        assert_eq!(bbox.max, tuple::Point::new(1.5, -1.0, 9.0));
+    }
+
+    #[test]
+    fn test_a_group_has_a_bounding_box_that_contains_its_children() {
+        let mut sphere = shape::Shape::default_sphere();
+        sphere.set_transformation_matrix(
+            matrix::Matrix4::IDENTITY
+                .scaling(2.0, 2.0, 2.0)
+                .translation(2.0, 5.0, -3.0),
+        );
+        let mut cylinder = shape::Shape::cylinder(-2.0, 2.0, false);
+        cylinder.set_transformation_matrix(
+            matrix::Matrix4::IDENTITY
+                .scaling(0.5, 1.0, 0.5)
+                .translation(-4.0, -1.0, 4.0),
+        );
+        let mut group = shape::Shape::default_group();
+        group.add_child(sphere);
+        group.add_child(cylinder);
+
+        let bbox = group.bounds();
+
+        assert_eq!(bbox.min, tuple::Point::new(-4.5, -3.0, -5.0));
+        assert_eq!(bbox.max, tuple::Point::new(4.0, 7.0, 4.5));
+    }
+
+    #[test]
+    fn test_a_csg_shape_has_a_bounding_box_that_contains_its_children() {
+        let left = shape::Shape::default_sphere();
+        let mut right = shape::Shape::default_sphere();
+        right.set_transformation_matrix(matrix::Matrix4::IDENTITY.translation(2.0, 3.0, 4.0));
+        let csg = shape::Shape::csg(shape::CsgOperation::Difference, left, right);
+
+        let bbox = csg.bounds();
+
+        assert_eq!(bbox.min, tuple::Point::new(-1.0, -1.0, -1.0));
+        assert_eq!(bbox.max, tuple::Point::new(3.0, 4.0, 5.0));
+    }
+
+    fn was_intersected(shape: &shape::Shape) -> bool {
+        match &shape.shape_type {
+            shape::ShapeType::Test { intersect_called } => intersect_called.get(),
+            _ => panic!("expected a test shape"),
+        }
+    }
+
+    fn children(group: &shape::Shape) -> &Vec<shape::Shape> {
+        match &group.shape_type {
+            shape::ShapeType::Group { children } => children,
+            _ => panic!("expected a group"),
+        }
+    }
+
+    fn csg_children(csg: &shape::Shape) -> (&shape::Shape, &shape::Shape) {
+        match &csg.shape_type {
+            shape::ShapeType::Csg { left, right, .. } => (left, right),
+            _ => panic!("expected a csg shape"),
+        }
+    }
+
+    #[test]
+    fn test_intersecting_a_group_skips_the_children_if_the_box_is_missed() {
+        let mut group = shape::Shape::default_group();
+        group.add_child(shape::Shape::test_shape());
+        let ray = ray::ray(
+            tuple::Point::new(0.0, 0.0, -5.0),
+            tuple::Vector::new(0.0, 1.0, 0.0),
+        );
+
+        group.intersect(&ray);
+
+        assert!(!was_intersected(&children(&group)[0]));
+    }
+
+    #[test]
+    fn test_intersecting_a_group_tests_the_children_if_the_box_is_hit() {
+        let mut group = shape::Shape::default_group();
+        group.add_child(shape::Shape::test_shape());
+        let ray = ray::ray(
+            tuple::Point::new(0.0, 0.0, -5.0),
+            tuple::Vector::new(0.0, 0.0, 1.0),
+        );
+
+        group.intersect(&ray);
+
+        assert!(was_intersected(&children(&group)[0]));
+    }
+
+    #[test]
+    fn test_intersecting_a_csg_shape_skips_the_children_if_the_box_is_missed() {
+        let csg = shape::Shape::csg(
+            shape::CsgOperation::Difference,
+            shape::Shape::test_shape(),
+            shape::Shape::test_shape(),
+        );
+        let ray = ray::ray(
+            tuple::Point::new(0.0, 0.0, -5.0),
+            tuple::Vector::new(0.0, 1.0, 0.0),
+        );
+
+        csg.intersect(&ray);
+
+        let (left, right) = csg_children(&csg);
+        assert!(!was_intersected(left));
+        assert!(!was_intersected(right));
+    }
+
+    #[test]
+    fn test_intersecting_a_csg_shape_tests_the_children_if_the_box_is_hit() {
+        let csg = shape::Shape::csg(
+            shape::CsgOperation::Difference,
+            shape::Shape::test_shape(),
+            shape::Shape::test_shape(),
+        );
+        let ray = ray::ray(
+            tuple::Point::new(0.0, 0.0, -5.0),
+            tuple::Vector::new(0.0, 0.0, 1.0),
+        );
+
+        csg.intersect(&ray);
+
+        let (left, right) = csg_children(&csg);
+        assert!(was_intersected(left));
+        assert!(was_intersected(right));
     }
 }


### PR DESCRIPTION
Implements the first half of the ["Bounding boxes and hierarchies" bonus chapter](http://www.raytracerchallenge.com/bonus/bounding-boxes.html): axis-aligned bounding boxes and the intersection guard for aggregate shapes.

A new `bounds::BoundingBox` type holds min/max extents, grows to enclose added points and boxes, answers containment queries, transforms by re-boxing all eight corners (a rotated AABB is no longer axis-aligned), and reports whether a ray strikes it using the cube intersection generalized to arbitrary extents. Every shape reports its object-space box via `bounds()`, and `parent_space_bounds()` carries it through the shape's own transform. Group and CSG intersection first test the ray against the box enclosing all children and skip the whole subtree when it misses.

Aggregates cache their box rather than recomputing it per ray, which would cost more than the child tests it avoids: a group grows its box incrementally in `add_child`, and a CSG shape computes it once at construction, since its children never change afterwards.

**Results:** the high-poly teapot render test drops from 14.3s to 5.9s, and the low-poly one from 0.56s to 0.24s. All render fixtures are pixel-identical — the guard only skips work, it never changes what a ray hits.

The chapter's second half (bounding volume hierarchies: `split_bounds` / `partition_children` / `divide`) is left for a follow-up PR, and replaces the resolved bounding-boxes entry in the README's "Possible improvements" list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)